### PR TITLE
DMESUPPORT-131 updated Mocha using caching and error logging

### DIFF
--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/DmeMetadataBuilder.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/DmeMetadataBuilder.java
@@ -55,16 +55,16 @@ public class DmeMetadataBuilder {
 		return ExcelUtil.parseBulkMetadataEntries(metadataFile, key);
 	}
 	
-	@Cacheable(value = "metadata", key = "'dmeMetadata'", sync = true)
-	public Map<String, Map<String, String>> getMetadataMap(String metadataFile, String key1, String key2)
+	@Cacheable(value = "metadata", key = "'dmeMetadataTwoKeys'", sync = true)
+	public Map<String, Map<String, String>> getMetadataMapWithTwoKeys(String metadataFile, String key1, String key2)
 			throws DmeSyncMappingException, DmeSyncWorkflowException, IOException {
 
 		logger.info("Parsing the Metadata Spreadsheet and creating Metadata Map");
 		return ExcelUtil.parseBulkMetadataEntries(metadataFile, key1, key2);
 	}
 
-	@CachePut(value = "metadata", key = "'dmeMetadata'")
-	public Map<String, Map<String, String>> updateMetadataMap(String metadataFile, String key1, String key2)
+	@CachePut(value = "metadata", key = "'dmeMetadataTwoKeys'")
+	public Map<String, Map<String, String>> updateMetadataMapWithTwoKeys(String metadataFile, String key1, String key2)
 			throws DmeSyncMappingException, DmeSyncWorkflowException, IOException {
 
 		logger.info("Updating the Metadata Spreadsheet and creating Metadata Map");

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
@@ -59,6 +59,8 @@ public abstract class AbstractPathMetadataProcessor implements DmeSyncPathMetada
   Map<String, Map<String, String>> metadataMap = null;
   
   Map<String, Map<String, String>> piMetadataMap = null;
+  
+  Map<String, Map<String, String>> metadataMapWithTwoKeys = null;
 
 
   protected static ThreadLocal<Map<String, Map<String, String>>> threadLocalMap = new ThreadLocal<Map<String, Map<String, String>>>() {
@@ -342,7 +344,7 @@ public abstract class AbstractPathMetadataProcessor implements DmeSyncPathMetada
 	
 	public String getAttrValueWithParitallyMatchingKey(String partialKey, String attrKey) throws DmeSyncMappingException {
 	    String key = null;
-	    for (Map.Entry<String, Map<String, String>> entry : metadataMap.entrySet()) {
+	    for (Map.Entry<String, Map<String, String>> entry : metadataMapWithTwoKeys.entrySet()) {
 	        if(StringUtils.contains(entry.getKey(), partialKey)) {
 	          //Partial key match.
 	          key = entry.getKey();
@@ -353,7 +355,7 @@ public abstract class AbstractPathMetadataProcessor implements DmeSyncPathMetada
 	      logger.error("Excel mapping not found for partial key {}", partialKey);
 	      throw new DmeSyncMappingException("Excel mapping not found for " + partialKey);
 	    }
-	    String attrValue = metadataMap.get(key).get(attrKey);
+	    String attrValue = metadataMapWithTwoKeys.get(key).get(attrKey);
 	    return attrValue;
   }
 
@@ -362,7 +364,7 @@ public abstract class AbstractPathMetadataProcessor implements DmeSyncPathMetada
 	      logger.error("Excel mapping not found for {}", key1 + key2);
 	      return null;
 	    }
-	    return (metadataMap.get(key1 + "_" + key2) == null? null : metadataMap.get(key1 + "_" + key2).get(attrKey));
+	    return (metadataMapWithTwoKeys.get(key1 + "_" + key2) == null? null : metadataMapWithTwoKeys.get(key1 + "_" + key2).get(attrKey));
    }
   
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
@@ -344,6 +344,10 @@ public abstract class AbstractPathMetadataProcessor implements DmeSyncPathMetada
 	
 	public String getAttrValueWithParitallyMatchingKey(String partialKey, String attrKey) throws DmeSyncMappingException {
 	    String key = null;
+	    
+	    if (metadataMapWithTwoKeys == null || metadataMapWithTwoKeys.isEmpty()) {
+	    	return null;
+	    }
 	    for (Map.Entry<String, Map<String, String>> entry : metadataMapWithTwoKeys.entrySet()) {
 	        if(StringUtils.contains(entry.getKey(), partialKey)) {
 	          //Partial key match.

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
@@ -342,7 +342,7 @@ public abstract class AbstractPathMetadataProcessor implements DmeSyncPathMetada
 		return (piMetadataMap.get(key) == null ? null : piMetadataMap.get(key).get(attrKey));
 	}
 	
-	public String getAttrValueWithParitallyMatchingKey(String partialKey, String attrKey) throws DmeSyncMappingException {
+	public String getAttrValueWithParitallyMatchingKeyFromMapWithTwoKeys(String partialKey, String attrKey) throws DmeSyncMappingException {
 	    String key = null;
 	    
 	    if (metadataMapWithTwoKeys == null || metadataMapWithTwoKeys.isEmpty()) {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/MochaPathMetadataProcessorImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/MochaPathMetadataProcessorImpl.java
@@ -339,7 +339,7 @@ public class MochaPathMetadataProcessorImpl extends AbstractPathMetadataProcesso
 		  // For fastq, get the Platform from the spreadsheet by using only Run_ID
 		  String runId = getRunId(object);
 		  try {
-			  platform = getAttrValueWithParitallyMatchingKey(runId, "Platform");
+			  platform = getAttrValueWithParitallyMatchingKeyFromMapWithTwoKeys(runId, "Platform");
 		  } catch (DmeSyncMappingException e) {
 			  throw new DmeSyncMappingException("Run ID is missing from spreadsheet. Run_ID: " + runId);
 		  }
@@ -361,7 +361,7 @@ public class MochaPathMetadataProcessorImpl extends AbstractPathMetadataProcesso
 		  flowcellId = StringUtils.substringAfterLast(runId, "_");
 		  flowcellId = StringUtils.substring(flowcellId, 1);
 	  } else {
-		  flowcellId = getAttrValueWithParitallyMatchingKey(runId, "Flowcell");
+		  flowcellId = getAttrValueWithParitallyMatchingKeyFromMapWithTwoKeys(runId, "Flowcell");
 	  }
 	return flowcellId;
   }

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/MochaPathMetadataProcessorImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/MochaPathMetadataProcessorImpl.java
@@ -198,7 +198,7 @@ public class MochaPathMetadataProcessorImpl extends AbstractPathMetadataProcesso
         	String runId = getRunId(object);
         	String flowcellId = getFlowcellId(object);
     	    String sampleId = getSampleId(object);
-			String projectCollectionPath = platformCollectionPath + "/Project_" + projectCollectionName;
+			String projectCollectionPath = platformCollectionPath + "/Project_" + projectCollectionName.replace(" ", "_");
 			HpcBulkMetadataEntry pathEntriesProject = new HpcBulkMetadataEntry();
 			HpcBulkMetadataEntry hpcBulkMetadataProjectEntries = populateStoredMetadataEntries(pathEntriesProject,
 					"Project", projectCollectionName, "mocha");
@@ -208,7 +208,7 @@ public class MochaPathMetadataProcessorImpl extends AbstractPathMetadataProcesso
 				// It is null or empty means no mapping for project in database
 				String msg = "No metadata entries were found for Collection Type " + "Project"
 						+ " with Project Mapping Key: " + projectCollectionName;
-				logger.info(msg);
+				logger.error(msg);
 				throw new DmeSyncMappingException(msg);
 			}
 			pathEntriesProject.getPathMetadataEntries().add(createPathEntry(COLLECTION_TYPE_ATTRIBUTE, "Project"));

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/MochaPathMetadataProcessorImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/MochaPathMetadataProcessorImpl.java
@@ -57,7 +57,7 @@ public class MochaPathMetadataProcessorImpl extends AbstractPathMetadataProcesso
     logger.info("[PathMetadataTask] Mocha getArchivePath called");
     
     // load the user metadata from the externally placed excel
-    metadataMap = dmeMetadataBuilder.getMetadataMap(metadataFile, "Run_ID", "Sample");
+    metadataMapWithTwoKeys = dmeMetadataBuilder.getMetadataMapWithTwoKeys(metadataFile, "Run_ID", "Sample");
     
     // Example source path -
     // /mnt/mocha_static/NovaSeq/220113_A00424_0160_BHKJNWDSX2/Data/Intensities/BaseCalls/L001
@@ -200,13 +200,23 @@ public class MochaPathMetadataProcessorImpl extends AbstractPathMetadataProcesso
     	    String sampleId = getSampleId(object);
 			String projectCollectionPath = platformCollectionPath + "/Project_" + projectCollectionName;
 			HpcBulkMetadataEntry pathEntriesProject = new HpcBulkMetadataEntry();
+			HpcBulkMetadataEntry hpcBulkMetadataProjectEntries = populateStoredMetadataEntries(pathEntriesProject,
+					"Project", projectCollectionName, "mocha");
+
+			if (hpcBulkMetadataProjectEntries == null || hpcBulkMetadataProjectEntries.getPathMetadataEntries() == null
+					|| hpcBulkMetadataProjectEntries.getPathMetadataEntries().isEmpty()) {
+				// It is null or empty means no mapping for project in database
+				String msg = "No metadata entries were found for Collection Type " + "Project"
+						+ " with Project Mapping Key: " + projectCollectionName;
+				logger.info(msg);
+				throw new DmeSyncMappingException(msg);
+			}
 			pathEntriesProject.getPathMetadataEntries().add(createPathEntry(COLLECTION_TYPE_ATTRIBUTE, "Project"));
 			pathEntriesProject.getPathMetadataEntries().add(createPathEntry("project_id", projectCollectionName));
 			pathEntriesProject.getPathMetadataEntries().add(createPathEntry("project_status", "Active"));
 			pathEntriesProject.setPath(projectCollectionPath);
-			hpcBulkMetadataEntries.getPathsMetadataEntries()
-			.add(populateStoredMetadataEntries(pathEntriesProject, "Project", projectCollectionName, "mocha"));
-		    
+			hpcBulkMetadataEntries.getPathsMetadataEntries().add(hpcBulkMetadataProjectEntries);
+			
 		    // Add path metadata entries for "Sample" collection
 		    // Example row: collectionType - Sample, collectionName - Sample_<SampleId>
 		    // sample_id, value = PDA01236 (derived)
@@ -377,8 +387,8 @@ public class MochaPathMetadataProcessorImpl extends AbstractPathMetadataProcesso
 		flowcellCollectionName = getCollectionNameFromParent(object, "mocha_static");
 	} else if (path.contains("mocha_ngs") && path.contains("Dragen_TSO500")) {
 		flowcellCollectionName = getCollectionNameFromParent(object, "dragen_bcl2fastqconvert");
-		//if (flowcellCollectionName != null)
-		///	flowcellCollectionName=flowcellCollectionName.replace("Dragen_BCL_", "");
+		 if (flowcellCollectionName != null)
+		   flowcellCollectionName=flowcellCollectionName.replace("Dragen_BCL_", "DRAGEN_TSO500_V2_");
 	}
 	return flowcellCollectionName;
   }
@@ -443,9 +453,9 @@ public class MochaPathMetadataProcessorImpl extends AbstractPathMetadataProcesso
   
   private String getSampleFromFilePath(String path, String folderName) {
 	    String sampleName = null;
-	    for (Map.Entry<String, Map<String, String>> entry : metadataMap.entrySet()) {
+	    for (Map.Entry<String, Map<String, String>> entry : metadataMapWithTwoKeys.entrySet()) {
 	        if(StringUtils.startsWith(entry.getKey(), folderName)) {
-	        	String sampleEntry = metadataMap.get(entry.getKey()).get("Sample");
+	        	String sampleEntry = metadataMapWithTwoKeys.get(entry.getKey()).get("Sample");
 		        if(StringUtils.containsIgnoreCase(path, sampleEntry)) {
 		          //Sample is present in the file path
 		          sampleName = sampleEntry;

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncDataObjectListQuery.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncDataObjectListQuery.java
@@ -93,7 +93,7 @@ public class DmeSyncDataObjectListQuery {
 				HpcPathAttributes pathAttributes = new HpcPathAttributes();
 				pathAttributes.setName(Paths.get(dataObject.getDataObject().getAbsolutePath()).getFileName().toString());
 				pathAttributes.setPath(dataObject.getDataObject().getAbsolutePath());
-				//pathAttributes.setUpdatedDate(dataObject.getDataObject().getData().getTime());
+				pathAttributes.setUpdatedDate(dataObject.getDataObject().getCreatedAt().getTime());
 				pathAttributes.setAbsolutePath(dataObject.getDataObject().getAbsolutePath());
 				pathAttributes.setIsDirectory(false);
 				attributes.add(pathAttributes);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncDataObjectListQuery.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncDataObjectListQuery.java
@@ -93,7 +93,7 @@ public class DmeSyncDataObjectListQuery {
 				HpcPathAttributes pathAttributes = new HpcPathAttributes();
 				pathAttributes.setName(Paths.get(dataObject.getDataObject().getAbsolutePath()).getFileName().toString());
 				pathAttributes.setPath(dataObject.getDataObject().getAbsolutePath());
-				pathAttributes.setUpdatedDate(dataObject.getDataObject().getCreatedAt().getTime());
+				//pathAttributes.setUpdatedDate(dataObject.getDataObject().getData().getTime());
 				pathAttributes.setAbsolutePath(dataObject.getDataObject().getAbsolutePath());
 				pathAttributes.setIsDirectory(false);
 				attributes.add(pathAttributes);


### PR DESCRIPTION
Below changes are covered in this. PR:

1.  Identified metadata has new key for Run_id from May 2025 datasets. Previously, In spreadsheet run_id values used to be Dragen_BCL_<runnumber>, matching the folder name. From May 2025 onward folders, it changed to DRAGEN_TSO500_V2_<runnumber>.  fixed the issue with the Run_id key changes in the workflow for Tso500 files 
2. Identified that when project mappings are not found, the error does not explicitly indicate that metadata for the project key is missing in the database; instead, it shows the upload task message, “The following metadata is missing.” Added a validation step to ensure that project-level stored metadata mappings exist before proceeding with the upload task. This applies to mocha bcl, tso500, novaseq.
3. Improved the caching metadata map names to explicitly define the metadata map is constructed using two keys 
 