### PR TITLE
DMESUPPORT-193 Remove reference to deprecated field HpcDataObjectDTO.…

### DIFF
--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -274,7 +274,7 @@ public class DmeSyncScheduler {
     try {
       List<HpcPathAttributes> paths = null;
       if(createSoftlink) {
-    	  paths = queryDataObjects();
+    	  paths = queryDataObjectsForSoftlinkCreation();
       } else if (noScanRerun) {
         findFilesToRerun();
         logger.info(
@@ -524,7 +524,7 @@ public class DmeSyncScheduler {
     return result;
   }
   
-  private List<HpcPathAttributes> queryDataObjects() throws HpcException, IOException {
+  private List<HpcPathAttributes> queryDataObjectsForSoftlinkCreation() throws HpcException, IOException {
     List<HpcPathAttributes> result = new ArrayList<>();
     Path filePath = Paths.get(sourceSoftlinkFile);
     List<String> lines = Files.readAllLines(filePath);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncDataObjectListQuery.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncDataObjectListQuery.java
@@ -93,7 +93,6 @@ public class DmeSyncDataObjectListQuery {
 				HpcPathAttributes pathAttributes = new HpcPathAttributes();
 				pathAttributes.setName(Paths.get(dataObject.getDataObject().getAbsolutePath()).getFileName().toString());
 				pathAttributes.setPath(dataObject.getDataObject().getAbsolutePath());
-				pathAttributes.setUpdatedDate(dataObject.getDataObject().getCreatedAt().getTime());
 				pathAttributes.setAbsolutePath(dataObject.getDataObject().getAbsolutePath());
 				pathAttributes.setIsDirectory(false);
 				attributes.add(pathAttributes);


### PR DESCRIPTION
The HpcDataObjectDTO.createdAt field is deprecated and will be removed in the next DME release with the following ticket.
HPCDATAMGM-2164: Remove unnecessary attributes in HpcDataObject

There is one reference to this field which is not used, so it can be removed. we make this method queryDataObjects softlink specific like queryDataObjectsForSoftlinkCreation as well.