### PR TITLE
DMESUPPORT-175 Enhance metadata validation before tarring and validate required metadata

### DIFF
--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncMetadataTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncMetadataTaskImpl.java
@@ -32,7 +32,6 @@ import gov.nih.nci.hpc.dto.datamanagement.v2.HpcDataObjectRegistrationRequestDTO
 public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeSyncTask {
 
   @Autowired private DmeSyncPathMetadataProcessorFactory metadataProcessorFactory;
-  @Autowired static MessageService messageService;
 
   @Value("${dmesync.doc.name:default}")
   private String doc;
@@ -97,7 +96,7 @@ public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeS
       
         if (!validationResult.getValid()) {
 			if (StringUtils.isEmpty(validationResult.getMessage())) {
-				throw new DmeSyncMappingException(messageService.get("INVALID_METADATA_MSG"));
+				throw new DmeSyncMappingException("Invalid metadata entry in request");
 			} else {
 				throw new DmeSyncMappingException(validationResult.getMessage());
 			}
@@ -207,7 +206,7 @@ public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeS
 				
 				if (StringUtils.isEmpty(metadataEntry.getAttribute())) {
 					validationResult.setValid(false);
-					validationResult.setMessage(messageService.get("EMPTY_METADATA_MSG"));
+					validationResult.setMessage("Empty metadata entry in request");
 					return validationResult;
 
 				} else {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncMetadataTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncMetadataTaskImpl.java
@@ -87,15 +87,22 @@ public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeS
         dataObjectRegistrationRequestDTO.getExtractedMetadataEntries().addAll(extractedMetadataEntries);
       }
       
-      HpcDomainValidationResult validationResult = isValidMetadataEntries( dataObjectRegistrationRequestDTO.getParentCollectionsBulkMetadataEntries().getPathsMetadataEntries(),false);
+      HpcBulkMetadataEntries  pathMetadataEntries = null;
+      if (dataObjectRegistrationRequestDTO != null) {
+    	  pathMetadataEntries = dataObjectRegistrationRequestDTO.getParentCollectionsBulkMetadataEntries() ;
+      }
       
-    /*  if (!validationResult.getValid()) {
+      if (pathMetadataEntries!=null && pathMetadataEntries.getPathsMetadataEntries()!= null) {
+        HpcDomainValidationResult validationResult = isValidMetadataEntries(pathMetadataEntries.getPathsMetadataEntries(),false);
+      
+        if (!validationResult.getValid()) {
 			if (StringUtils.isEmpty(validationResult.getMessage())) {
 				throw new DmeSyncMappingException(messageService.get("INVALID_METADATA_MSG"));
 			} else {
 				throw new DmeSyncMappingException(validationResult.getMessage());
 			}
-		} */
+		} 
+      }
       
       //Save Metadata Info in DB
       saveMetaDataInfo(object, dataObjectRegistrationRequestDTO);
@@ -168,16 +175,36 @@ public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeS
 			boolean editMetadata) throws DmeSyncMappingException {
 		HpcDomainValidationResult validationResult = new HpcDomainValidationResult();
 		validationResult.setValid(true);
+		
+		if (bulkMetadataEntries == null) {
+ 			validationResult.setValid(false);
+ 			validationResult.setMessage("Metadata entry collection cannot be null.");
+ 			return validationResult;
+ 		}
 
 		for (HpcBulkMetadataEntry bulkMetadataEntry : bulkMetadataEntries) {
+			
+			if (bulkMetadataEntry == null) {
+ 				validationResult.setValid(false);
+ 				validationResult.setMessage("Bulk metadata entry cannot be null.");
+ 				return validationResult;
+ 			}
 
 			List<HpcMetadataEntry> list = bulkMetadataEntry.getPathMetadataEntries();
 			if (list == null) {
 				validationResult.setValid(false);
+				validationResult.setMessage("Path metadata entries cannot be null.");
 				return validationResult;
 			}
 			for (int i = 0; i < list.size(); i++) {
 				HpcMetadataEntry metadataEntry = list.get(i);
+				
+				if (metadataEntry == null) {
+ 					validationResult.setValid(false);
+ 					validationResult.setMessage("Metadata entry cannot be null.");
+ 					return validationResult;
+ 				}
+				
 				if (StringUtils.isEmpty(metadataEntry.getAttribute())) {
 					validationResult.setValid(false);
 					validationResult.setMessage(messageService.get("EMPTY_METADATA_MSG"));

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncMetadataTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncMetadataTaskImpl.java
@@ -32,6 +32,7 @@ import gov.nih.nci.hpc.dto.datamanagement.v2.HpcDataObjectRegistrationRequestDTO
 public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeSyncTask {
 
   @Autowired private DmeSyncPathMetadataProcessorFactory metadataProcessorFactory;
+  @Autowired private MessageService messageService;
 
   @Value("${dmesync.doc.name:default}")
   private String doc;
@@ -96,8 +97,10 @@ public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeS
       
         if (!validationResult.getValid()) {
 			if (StringUtils.isEmpty(validationResult.getMessage())) {
-				throw new DmeSyncMappingException("Invalid metadata entry in request");
+				logger.error("[{}] Validation Error while creating path and metadata:  {} ", super.getTaskName(), messageService.get("INVALID_METADATA_MSG"));
+				throw new DmeSyncMappingException(messageService.get("INVALID_METADATA_MSG"));
 			} else {
+				logger.error("[{}] Validation Error while creating path and metadata:  {} ", super.getTaskName(), validationResult.getMessage());
 				throw new DmeSyncMappingException(validationResult.getMessage());
 			}
 		} 
@@ -170,14 +173,14 @@ public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeS
 	 * @return true if valid, false otherwise.
 	 * @throws DmeSyncMappingException 
 	 */
-	public static HpcDomainValidationResult isValidMetadataEntries(List<HpcBulkMetadataEntry> bulkMetadataEntries,
+	private HpcDomainValidationResult isValidMetadataEntries(List<HpcBulkMetadataEntry> bulkMetadataEntries,
 			boolean editMetadata) throws DmeSyncMappingException {
 		HpcDomainValidationResult validationResult = new HpcDomainValidationResult();
 		validationResult.setValid(true);
 		
 		if (bulkMetadataEntries == null) {
  			validationResult.setValid(false);
- 			validationResult.setMessage("Metadata entry collection cannot be null.");
+ 			validationResult.setMessage(messageService.get("EMPTY_COLLECTION_MSG"));
  			return validationResult;
  		}
 
@@ -185,14 +188,14 @@ public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeS
 			
 			if (bulkMetadataEntry == null) {
  				validationResult.setValid(false);
- 				validationResult.setMessage("Bulk metadata entry cannot be null.");
+ 				validationResult.setMessage(messageService.get("EMPTY_BULK_METADATA_MSG"));
  				return validationResult;
  			}
 
 			List<HpcMetadataEntry> list = bulkMetadataEntry.getPathMetadataEntries();
 			if (list == null) {
 				validationResult.setValid(false);
-				validationResult.setMessage("Path metadata entries cannot be null.");
+				validationResult.setMessage(messageService.get("EMPTY_PATH_METADATA_MSG"));
 				return validationResult;
 			}
 			for (int i = 0; i < list.size(); i++) {
@@ -200,13 +203,13 @@ public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeS
 				
 				if (metadataEntry == null) {
  					validationResult.setValid(false);
- 					validationResult.setMessage("Metadata entry cannot be null.");
+ 					validationResult.setMessage(messageService.get("NULL_METADATA_ENTRY_MSG"));
  					return validationResult;
  				}
 				
 				if (StringUtils.isEmpty(metadataEntry.getAttribute())) {
 					validationResult.setValid(false);
-					validationResult.setMessage("Empty metadata entry in request");
+					validationResult.setMessage(messageService.get("EMPTY_METADATA_MSG"));
 					return validationResult;
 
 				} else {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncMetadataTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncMetadataTaskImpl.java
@@ -15,6 +15,8 @@ import gov.nih.nci.hpc.dmesync.exception.DmeSyncMappingException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncWorkflowException;
 import gov.nih.nci.hpc.dmesync.workflow.DmeSyncPathMetadataProcessor;
 import gov.nih.nci.hpc.dmesync.workflow.DmeSyncTask;
+import gov.nih.nci.hpc.dmesync.workflow.MessageService;
+import gov.nih.nci.hpc.domain.error.HpcDomainValidationResult;
 import gov.nih.nci.hpc.domain.metadata.HpcBulkMetadataEntries;
 import gov.nih.nci.hpc.domain.metadata.HpcBulkMetadataEntry;
 import gov.nih.nci.hpc.domain.metadata.HpcMetadataEntry;
@@ -30,6 +32,7 @@ import gov.nih.nci.hpc.dto.datamanagement.v2.HpcDataObjectRegistrationRequestDTO
 public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeSyncTask {
 
   @Autowired private DmeSyncPathMetadataProcessorFactory metadataProcessorFactory;
+  @Autowired static MessageService messageService;
 
   @Value("${dmesync.doc.name:default}")
   private String doc;
@@ -83,6 +86,17 @@ public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeS
         List<HpcMetadataEntry> extractedMetadataEntries = metadataTask.extractMetadataFromFile(new File(object.getOriginalFilePath()));
         dataObjectRegistrationRequestDTO.getExtractedMetadataEntries().addAll(extractedMetadataEntries);
       }
+      
+      HpcDomainValidationResult validationResult = isValidMetadataEntries( dataObjectRegistrationRequestDTO.getParentCollectionsBulkMetadataEntries().getPathsMetadataEntries(),false);
+      
+    /*  if (!validationResult.getValid()) {
+			if (StringUtils.isEmpty(validationResult.getMessage())) {
+				throw new DmeSyncMappingException(messageService.get("INVALID_METADATA_MSG"));
+			} else {
+				throw new DmeSyncMappingException(validationResult.getMessage());
+			}
+		} */
+      
       //Save Metadata Info in DB
       saveMetaDataInfo(object, dataObjectRegistrationRequestDTO);
 
@@ -140,5 +154,56 @@ public class DmeSyncMetadataTaskImpl extends AbstractDmeSyncTask implements DmeS
       }
     }
   }
+  
+  /**
+	 * Validate metadata entry collection.
+	 *
+	 * @param list Metadata entry collection.
+	 * @param editMetadata    true if the metadata is being edited. This is to
+	 *                        enable delete.
+	 * @return true if valid, false otherwise.
+	 * @throws DmeSyncMappingException 
+	 */
+	public static HpcDomainValidationResult isValidMetadataEntries(List<HpcBulkMetadataEntry> bulkMetadataEntries,
+			boolean editMetadata) throws DmeSyncMappingException {
+		HpcDomainValidationResult validationResult = new HpcDomainValidationResult();
+		validationResult.setValid(true);
+
+		for (HpcBulkMetadataEntry bulkMetadataEntry : bulkMetadataEntries) {
+
+			List<HpcMetadataEntry> list = bulkMetadataEntry.getPathMetadataEntries();
+			if (list == null) {
+				validationResult.setValid(false);
+				return validationResult;
+			}
+			for (int i = 0; i < list.size(); i++) {
+				HpcMetadataEntry metadataEntry = list.get(i);
+				if (StringUtils.isEmpty(metadataEntry.getAttribute())) {
+					validationResult.setValid(false);
+					validationResult.setMessage(messageService.get("EMPTY_METADATA_MSG"));
+					return validationResult;
+
+				} else {
+					if (editMetadata == false && StringUtils.isEmpty(metadataEntry.getValue())) {
+						if (validationResult.getValid()) {
+							validationResult.setMessage(
+									"The following entries cannot be empty: " + metadataEntry.getAttribute());
+						} else {
+							validationResult
+									.setMessage(validationResult.getMessage() + ", " + metadataEntry.getAttribute());
+						}
+						validationResult.setValid(false);
+					} else {
+						list.get(i).setAttribute(list.get(i).getAttribute().trim());
+						list.get(i).setValue(StringUtils.isEmpty(metadataEntry.getValue()) ? metadataEntry.getValue()
+								: list.get(i).getValue().trim());
+					}
+				}
+			}
+		}
+		return validationResult;
+
+	}
+  
   
 }

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarPreProcessTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarPreProcessTaskImpl.java
@@ -1,7 +1,5 @@
 package gov.nih.nci.hpc.dmesync.workflow.impl;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -61,7 +59,7 @@ public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements
 
 	@PostConstruct
 	public boolean init() {
-		super.setTaskName("TarTask");
+		super.setTaskName("TarPreProcessingTask");
 		if (tarIndividualFiles)
 			super.setCheckTaskForCompletion(false);
 		return true;

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarPreProcessTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarPreProcessTaskImpl.java
@@ -60,6 +60,9 @@ public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements
 
 	@Value("${dmesync.process.multiple.tars:false}")
 	private boolean processMultipleTars;
+	
+	@Value("${dmesync.multiple.tars.dir.folders:}")
+	private String multipleTarsFolders;
 
 	@PostConstruct
 	public boolean init() {
@@ -96,8 +99,15 @@ public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements
 			Path relativePath = baseDirPath.relativize(sourceDirPath);
 			String tarWorkDir = workDirPath.toString() + File.separatorChar + relativePath.toString();
 			String tarFileName = null ;
+		
+			String sourceDirLeafNode = object.getOriginalFilePath() != null
+					? ((Paths.get(object.getOriginalFilePath())).getFileName()).toString()
+					: null;
 			
-			if(processMultipleTars) {
+			/** This condition when dmesync.process.multiple.tars is true  only applies to multipleTarsFolders
+			 * because the processMultipleTarsTask will set the sourcefilename
+			 */
+			if(processMultipleTars && TarUtil.matchesAnyMultipleTarFolder( multipleTarsFolders , sourceDirLeafNode )) {
 				tarFileName = object.getSourceFileName();
 			}else {
 			

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarPreProcessTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarPreProcessTaskImpl.java
@@ -1,0 +1,137 @@
+package gov.nih.nci.hpc.dmesync.workflow.impl;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.apache.commons.io.FilenameUtils;
+import gov.nih.nci.hpc.dmesync.util.ExcelUtil;
+import gov.nih.nci.hpc.dmesync.domain.StatusInfo;
+import gov.nih.nci.hpc.dmesync.exception.DmeSyncMappingException;
+import gov.nih.nci.hpc.dmesync.exception.DmeSyncStorageException;
+import gov.nih.nci.hpc.dmesync.exception.DmeSyncWorkflowException;
+import gov.nih.nci.hpc.dmesync.workflow.DmeSyncTask;
+
+/**
+ * DME Sync Tar Pre Process Task Implementation
+ * 
+ * @author konerum3
+ */
+@Component
+public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements DmeSyncTask {
+
+	@Value("${dmesync.doc.name}")
+	private String doc;
+
+	@Value("${dmesync.compress:false}")
+	private boolean compress;
+
+	@Value("${dmesync.source.base.dir}")
+	private String syncBaseDir;
+
+	@Value("${dmesync.work.base.dir}")
+	private String syncWorkDir;
+
+	@Value("${dmesync.file.tar:false}")
+	private boolean tarIndividualFiles;
+
+	@Value("${dmesync.multiple.tars.files.count:0}")
+	private Integer filesPerTar;
+
+	@Value("${dmesync.tar.filename.excel.exist:false}")
+	private boolean tarNameinExcelFile;
+
+	@Value("${dmesync.additional.metadata.excel:}")
+	private String metadataFile;
+
+	@Value("${dmesync.tar.contents.file:false}")
+	private boolean createTarContentsFile;
+
+	@Value("${dmesync.selective.scan:false}")
+	private boolean selectiveScan;
+
+	@Value("${dmesync.process.multiple.tars:false}")
+	private boolean processMultipleTars;
+
+	@PostConstruct
+	public boolean init() {
+		super.setTaskName("TarTask");
+		if (tarIndividualFiles)
+			super.setCheckTaskForCompletion(false);
+		return true;
+	}
+
+	protected static ThreadLocal<Map<String, Map<String, String>>> threadLocalMap = new ThreadLocal<Map<String, Map<String, String>>>() {
+		@Override
+		protected HashMap<String, Map<String, String>> initialValue() {
+			return new HashMap<>();
+		}
+	};
+
+	@Override
+	public StatusInfo process(StatusInfo object)
+			throws DmeSyncMappingException, DmeSyncWorkflowException, DmeSyncStorageException {
+
+
+		// Task: Create tar file in work directory for processing
+		try {
+
+			String tarFileName;
+			if (tarNameinExcelFile) {
+				threadLocalMap.set(loadMetadataFile(metadataFile, "Path"));
+				String path = FilenameUtils.separatorsToUnix(object.getOriginalFilePath() + "/");
+				tarFileName = getAttrValueWithKey(path, "tar_name");
+			} else {
+				tarFileName = object.getOrginalFileName() + ".tar";
+			}
+
+			logger.info("[{}] Updating source file name in {}", super.getTaskName(), tarFileName);
+
+			if (compress) {
+				tarFileName = tarFileName + ".gz";
+
+			}
+
+			// Update the record for metadata processing
+			object.setSourceFileName(tarFileName);
+			object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
+
+		} catch (Exception e) {
+			logger.error("[{}] error {}", super.getTaskName(), e.getMessage(), e);
+			throw new DmeSyncStorageException("Error occurred during pre processing for TarTask. " + e.getMessage(), e);
+		} finally {
+			threadLocalMap.remove();
+		}
+		return object;
+
+	}
+
+	public Map<String, Map<String, String>> loadMetadataFile(String metadataFile, String key)
+			throws DmeSyncMappingException {
+		return ExcelUtil.parseBulkMetadataEntries(metadataFile, key);
+	}
+
+	public String getAttrValueWithKey(String rowKey, String attrKey) throws Exception {
+		String key = null;
+		if (threadLocalMap.get() == null)
+			return null;
+		for (String partialKey : threadLocalMap.get().keySet()) {
+			if (StringUtils.contains(rowKey, partialKey)) {
+				key = partialKey;
+				break;
+			}
+		}
+		if (StringUtils.isEmpty(key)) {
+			logger.error("Excel mapping not found for {}", rowKey);
+			throw new Exception("Excel mapping not found for {} " + rowKey);
+		}
+		return (threadLocalMap.get().get(key) == null ? null : threadLocalMap.get().get(key).get(attrKey));
+	}
+
+}

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarPreProcessTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarPreProcessTaskImpl.java
@@ -1,5 +1,6 @@
 package gov.nih.nci.hpc.dmesync.workflow.impl;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -63,8 +64,6 @@ public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements
 	@PostConstruct
 	public boolean init() {
 		super.setTaskName("TarPreProcessTask");
-		if (tarIndividualFiles)
-			super.setCheckTaskForCompletion(false);
 		return true;
 	}
 
@@ -89,10 +88,19 @@ public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements
 			return object;
 		}else {
 
-		// Task: update the tar file source name in database for metadata processing
+		// Task: update the tar file source name and source path in database for metadata processing
 		try {
-
-			String tarFileName;
+			Path baseDirPath = Paths.get(syncBaseDir).toRealPath();
+			Path workDirPath = Paths.get(syncWorkDir).toRealPath();
+			Path sourceDirPath = Paths.get(object.getOriginalFilePath());
+			Path relativePath = baseDirPath.relativize(sourceDirPath);
+			String tarWorkDir = workDirPath.toString() + File.separatorChar + relativePath.toString();
+			String tarFileName = null ;
+			
+			if(processMultipleTars) {
+				tarFileName = object.getSourceFileName();
+			}else {
+			
 			if (tarNameinExcelFile) {
 				threadLocalMap.set(loadMetadataFile(metadataFile, "Path"));
 				String path = FilenameUtils.separatorsToUnix(object.getOriginalFilePath() + "/");
@@ -100,8 +108,11 @@ public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements
 			} else {
 				tarFileName = object.getOrginalFileName() + ".tar";
 			}
+			}
+			String tarFile = tarWorkDir + File.separatorChar + tarFileName;
+			tarFile = Paths.get(tarFile).normalize().toString();
 
-			logger.info("[{}] Updating source file name in {}", super.getTaskName(), tarFileName);
+			logger.info("[{}] Updating source file name {} and source file path  {}", super.getTaskName(), tarFileName , tarFile );
 
 			if (compress) {
 				tarFileName = tarFileName + ".gz";
@@ -110,6 +121,7 @@ public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements
 
 			// Update the record for metadata processing
 			object.setSourceFileName(tarFileName);
+			object.setSourceFilePath(tarFile);
 			object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
 
 		} catch (Exception e) {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarPreProcessTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarPreProcessTaskImpl.java
@@ -1,5 +1,7 @@
 package gov.nih.nci.hpc.dmesync.workflow.impl;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.apache.commons.io.FilenameUtils;
 import gov.nih.nci.hpc.dmesync.util.ExcelUtil;
+import gov.nih.nci.hpc.dmesync.util.TarUtil;
 import gov.nih.nci.hpc.dmesync.domain.StatusInfo;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncMappingException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncStorageException;
@@ -59,7 +62,7 @@ public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements
 
 	@PostConstruct
 	public boolean init() {
-		super.setTaskName("TarPreProcessingTask");
+		super.setTaskName("TarPreProcessTask");
 		if (tarIndividualFiles)
 			super.setCheckTaskForCompletion(false);
 		return true;
@@ -76,8 +79,17 @@ public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements
 	public StatusInfo process(StatusInfo object)
 			throws DmeSyncMappingException, DmeSyncWorkflowException, DmeSyncStorageException {
 
+		Path originalFilePath=Paths.get(object.getOriginalFilePath());
+		
+		if((processMultipleTars || createTarContentsFile)  && object.getSourceFileName()!=null && StringUtils.contains(object.getSourceFileName(),"ContentsFile.txt")){
+			// Skipping this task for the contents file for multiple Tars and Tars processing
+			return object;	
+		}else if (selectiveScan && TarUtil.isSelectiveScanFileUpload(originalFilePath)){
+			// Skipping this task for the selective scan files upload
+			return object;
+		}else {
 
-		// Task: Create tar file in work directory for processing
+		// Task: update the tar file source name in database for metadata processing
 		try {
 
 			String tarFileName;
@@ -107,7 +119,7 @@ public class DmeSyncTarPreProcessTaskImpl extends AbstractDmeSyncTask implements
 			threadLocalMap.remove();
 		}
 		return object;
-
+	  }
 	}
 
 	public Map<String, Map<String, String>> loadMetadataFile(String metadataFile, String key)

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarTaskImpl.java
@@ -162,13 +162,13 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 		    File Folder = new File(object.getOriginalFilePath());
 	        
 	        object.setTarStartTimestamp(new Date());
-			// Construct work dir path
-			Path baseDirPath = Paths.get(syncBaseDir).toRealPath();
-			Path workDirPath = Paths.get(syncWorkDir).toRealPath();
+			// Retrieve the work dir path from database object
 			Path sourceDirPath = Paths.get(object.getOriginalFilePath());
-			Path relativePath = baseDirPath.relativize(sourceDirPath);
-			String tarWorkDir = workDirPath.toString() + File.separatorChar + relativePath.toString();
-			Path tarWorkDirPath = Paths.get(tarWorkDir);
+			
+	        Path tarFilepath = Paths.get(object.getSourceFilePath());
+	        String tarFile = tarFilepath.toString();
+	        Path tarWorkDirPath = tarFilepath.getParent();
+	        
 			
 			synchronized (this) {
 			Files.createDirectories(tarWorkDirPath);
@@ -180,7 +180,7 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 			// should be done for files in folders
 			if (processMultipleTars && object.getTarIndexStart() != null && object.getTarIndexEnd() != null) {
 
-				object=createTarForFiles(object, sourceDirPath, tarWorkDir, excludeFolders);
+				object=createTarForFiles(object, sourceDirPath, tarWorkDirPath.toString(), excludeFolders);
 				
 			} else {
 				long folderSize=TarUtil.getDirectorySize(originalFilePath,excludeFolders);
@@ -194,8 +194,7 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 				object.setTarStartTimestamp(new Date());
 				// TarFileName is constructed in the Pre Processing task
 				String tarFileName = object.getSourceFileName();
-				String tarFile = tarWorkDir + File.separatorChar + tarFileName;
-				tarFile = Paths.get(tarFile).normalize().toString();
+				// String tarFile = tarWorkDir + File.separatorChar + tarFileName;
 				File directory = new File(object.getOriginalFilePath());
 
 				logger.info("[{}] Creating tar file in {}", super.getTaskName(), tarFile);
@@ -233,7 +232,6 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 
 				object.setFilesize(createdTarFileSize);
 				object.setSourceFileName(tarFileName);
-				object.setSourceFilePath(tarFile);
 				object.setTarEndTimestamp(new Date());
 				object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarTaskImpl.java
@@ -192,14 +192,8 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 							+ ExcelUtil.humanReadableByteCount(maxAllowedFileSize, true));
 				} else {
 				object.setTarStartTimestamp(new Date());
-				String tarFileName;
-				if (tarNameinExcelFile) {
-					threadLocalMap.set(loadMetadataFile(metadataFile, "Path"));
-					String path = FilenameUtils.separatorsToUnix(object.getOriginalFilePath() + "/");
-					tarFileName = getAttrValueWithKey(path, "tar_name");
-				} else {
-					tarFileName = object.getOrginalFileName() + ".tar";
-				}
+				// TarFileName is constructed in the Pre Processing task
+				String tarFileName = object.getSourceFileName();
 				String tarFile = tarWorkDir + File.separatorChar + tarFileName;
 				tarFile = Paths.get(tarFile).normalize().toString();
 				File directory = new File(object.getOriginalFilePath());
@@ -213,8 +207,6 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 					throw new Exception("No Read permission to " + object.getOriginalFilePath());
 				}
 				if (compress) {
-					tarFile = tarFile + ".gz";
-					tarFileName = tarFileName + ".gz";
 					if (!dryRun) {
 						TarUtil.targz(tarFile, excludeFolders, ignoreBrokenLinksInTar, directory);
 					}

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarTaskImpl.java
@@ -35,7 +35,8 @@ import gov.nih.nci.hpc.dmesync.util.TarUtil;
 import gov.nih.nci.hpc.dmesync.util.WorkflowConstants;
 import gov.nih.nci.hpc.dmesync.workflow.DmeSyncPathMetadataProcessor;
 import gov.nih.nci.hpc.dmesync.workflow.DmeSyncTask;
-
+import gov.nih.nci.hpc.dto.datamanagement.HpcArchivePermissionsRequestDTO;
+import gov.nih.nci.hpc.dto.datamanagement.v2.HpcDataObjectRegistrationRequestDTO;
 /**
  * DME Sync Tar Task Implementation
  * 
@@ -136,6 +137,7 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 
 
 		DmeSyncPathMetadataProcessor metadataTask = metadataProcessorFactory.getService(doc);
+		final HpcDataObjectRegistrationRequestDTO hpcDataObjectRegistrationRequestDetails = object.getDataObjectRegistrationRequestDTO();
 		List<String> excludeFolders = excludeFolder == null || excludeFolder.isEmpty() ? null
 				: new ArrayList<>(Arrays.asList(excludeFolder.split(",")));
 		
@@ -180,7 +182,7 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 			// should be done for files in folders
 			if (processMultipleTars && object.getTarIndexStart() != null && object.getTarIndexEnd() != null) {
 
-				object=createTarForFiles(object, sourceDirPath, tarWorkDirPath.toString(), excludeFolders);
+				object=createTarForFiles(object, sourceDirPath, tarWorkDirPath.toString(), excludeFolders , hpcDataObjectRegistrationRequestDetails);
 				
 			} else {
 				long folderSize=TarUtil.getDirectorySize(originalFilePath,excludeFolders);
@@ -234,6 +236,7 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 				object.setSourceFileName(tarFileName);
 				object.setTarEndTimestamp(new Date());
 				object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
+				object.setDataObjectRegistrationRequestDTO(hpcDataObjectRegistrationRequestDetails);
 
 			}
 			}
@@ -254,7 +257,7 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 	}
 
 	private StatusInfo createTarForFiles(StatusInfo object, Path sourceDirPath, String tarWorkDir,
-			List<String> excludeFolders) throws Exception {
+			List<String> excludeFolders, HpcDataObjectRegistrationRequestDTO hpcDataObjectRegistrationRequestDetails) throws Exception {
 		
 		try{
 
@@ -370,6 +373,8 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 		object.setTarEndTimestamp(new Date());
 		object.setTarContentsCount(tarContentsCount);
 		object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
+		object.setDataObjectRegistrationRequestDTO(hpcDataObjectRegistrationRequestDetails);
+		
 	}catch(Exception e)
 	{
 		logger.error("[{}] error {}", super.getTaskName(), e.getMessage(), e);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
@@ -129,9 +129,6 @@ public class DmeSyncWorkflowImpl implements DmeSyncWorkflow {
     
     if (!awsFlag) {
     	if (processMultipleTars)  tasks.add(processMultipleTarsTask);
-    	if(tar && !processMultipleTars) {
-    		tasks.add(tarPreProcessTask);
-    	}
 	    if (tar || tarIndividualFiles || selectiveScan ) {
 	    	tasks.add(tarTask);
 	    	if(createTarContentsFile) {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
@@ -57,7 +57,7 @@ public class DmeSyncWorkflowImpl implements DmeSyncWorkflow {
   @Autowired private DmeSyncCreateSoftlinkTaskImpl createSoftlinkTask;
   @Autowired private DmeSyncCreateCollectionSoftlinkTaskImpl createCollectionSoftlinkTask;
   @Autowired private DmeSyncMoveDataObjectTaskImpl moveDataObjectTask;
-  
+  @Autowired private DmeSyncTarPreProcessTaskImpl tarPreProcessTask;
   @Value("${dmesync.db.access:local}")
   private String access;
 
@@ -116,8 +116,22 @@ public class DmeSyncWorkflowImpl implements DmeSyncWorkflow {
   public boolean init() {
     // Workflow init, add all applicable tasks, also need to create taskImpl class
     tasks = new ArrayList<>();
+    
+    // add a PreProcess task for tars
     if (!awsFlag) {
     	if (processMultipleTars)  tasks.add(processMultipleTarsTask);
+    	if(tar && !processMultipleTars) {
+    		tasks.add(tarPreProcessTask);
+    	}
+    }
+    
+    tasks.add(metadataTask);
+    
+    if (!awsFlag) {
+    	if (processMultipleTars)  tasks.add(processMultipleTarsTask);
+    	if(tar && !processMultipleTars) {
+    		tasks.add(tarPreProcessTask);
+    	}
 	    if (tar || tarIndividualFiles || selectiveScan ) {
 	    	tasks.add(tarTask);
 	    	if(createTarContentsFile) {
@@ -127,8 +141,6 @@ public class DmeSyncWorkflowImpl implements DmeSyncWorkflow {
 	    else if (compress) tasks.add(compressTask);
 	    if (untar) tasks.add(untarTask);
     }
-
-    tasks.add(metadataTask);
 
     if (!dryRun) {
       if(checksum && !createSoftlink && !createCollectionSoftlink && !moveProcessedFiles && !awsFlag)

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
@@ -120,7 +120,7 @@ public class DmeSyncWorkflowImpl implements DmeSyncWorkflow {
     // add a PreProcess task for tars
     if (!awsFlag) {
     	if (processMultipleTars)  tasks.add(processMultipleTarsTask);
-    	if(tar ) {
+    	if(tar || tarIndividualFiles || selectiveScan ) {
     		tasks.add(tarPreProcessTask);
     	}
     }

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
@@ -120,7 +120,7 @@ public class DmeSyncWorkflowImpl implements DmeSyncWorkflow {
     // add a PreProcess task for tars
     if (!awsFlag) {
     	if (processMultipleTars)  tasks.add(processMultipleTarsTask);
-    	if(tar && !processMultipleTars) {
+    	if(tar ) {
     		tasks.add(tarPreProcessTask);
     	}
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,5 +1,2 @@
 ARCHIVE_001=Failed to archive item {0}.
-VALIDATION_001=File location does not match the configured DME Hierarchy 
-VALIDATION_002= Excel mapping not found for {0}
-EMPTY_METADATA_MSG=Empty metadata entry in request
-INVALID_METADATA_MSG=Invalid metadata entry in request
+VALIDATION_001=File location does not match the configured DME Hierarchy

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,2 +1,5 @@
 ARCHIVE_001=Failed to archive item {0}.
 VALIDATION_001=File location does not match the configured DME Hierarchy 
+VALIDATION_002= Excel mapping not found for {0}
+EMPTY_METADATA_MSG=Empty metadata entry in request
+INVALID_METADATA_MSG=Invalid metadata entry in request

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,2 +1,8 @@
-ARCHIVE_001=Failed to archive item {0}.
-VALIDATION_001=File location does not match the configured DME Hierarchy
+VALIDATION_001=File location does not match the configured DME Hierarchy 
+VALIDATION_002= Excel mapping not found for {0}
+EMPTY_METADATA_MSG=Empty metadata entry in request
+INVALID_METADATA_MSG=Invalid metadata entry in request.
+EMPTY_COLLECTION_MSG=Metadata entry collection cannot be null.
+EMPTY_BULK_METADATA_MSG=Bulk metadata entry cannot be null.
+EMPTY_PATH_METADATA_MSG=Path metadata entries cannot be null.
+NULL_METADATA_ENTRY_MSG=Metadata entry cannot be null.


### PR DESCRIPTION
1. Reorder workflow tasks so Metadata processing and validation occurs before TAR creation.
2. Prevent TAR files from accumulating in the TAR/workspace when metadata is missing/invalid.
3. Introduce a PreProcessing (planning) task to compute StatusInfo.sourceFileName ,  StatusInfo.sourceFilePath  before metadata processing, because metadata processors depend on object.getSourceFilePath() today.
4. Add validation in framework metadata task to ensure metadata entries and their fields are not null. 
