### PR TITLE
GB_OMICS Workflow Minor fixes

### DIFF
--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -116,9 +116,10 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
    * findTopStatusInfoByDocAndSourceFilePath
    * @param doc the doc
    * @param sourceFilePath 
+   * @param originalFilePath
    * @return the original StatusInfo object for multiple tars 
    */
-  StatusInfo findTopStatusInfoByDocAndSourceFilePath(String doc, String sourceFilePath);
+  StatusInfo findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath(String doc, String sourceFilePath , String originalFilePath);
 
   /**
    * findTopStatusInfoByDocAndSourceFilePathAndRunId

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -113,7 +113,7 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   StatusInfo findTopStatusInfoByDocAndOriginalFilePathStartsWithOrderByStartTimestampDesc(String doc, String baseDir);
 
   /**
-   * findTopStatusInfoByDocAndSourceFilePath
+   * findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath
    * @param doc the doc
    * @param sourceFilePath 
    * @param originalFilePath

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -600,8 +600,8 @@ public class DmeSyncScheduler {
 			if (!mulitpleTarRequests.isEmpty()) {
 				// Retrieve the original Tar object where multiple tars are created mainly for rerun 
 				statusInfo = dmeSyncWorkflowService.getService(access)
-						.findTopStatusInfoByDocAndSourceFilePath(doc,
-								file.getAbsolutePath());
+						.findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath(doc,
+								file.getAbsolutePath() , file.getAbsolutePath());
 				List<StatusInfo> statusInfoNotCompletedList = mulitpleTarRequests.stream().filter(c -> c.getStatus() == null)
 						.collect(Collectors.toList());
 				if (!statusInfoNotCompletedList.isEmpty() || ((statusInfo!=null && statusInfo.getTarContentsCount()>0))) {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -729,6 +729,8 @@ public class DmeSyncScheduler {
 			}
 		}
 		else if(createCollectionSoftlink) {
+			 logger.debug(
+		              "[Scheduler] Original filepath : {} , SourceFilePath: {}",  file.getAbsolutePath() , file.getPath());
 			statusInfo =
 		              dmeSyncWorkflowService.getService(access).findFirstStatusInfoByOriginalFilePathAndSourceFilePathAndStatus(
 		                  file.getAbsolutePath(), file.getPath(), "COMPLETED");
@@ -761,6 +763,14 @@ public class DmeSyncScheduler {
                         dmeSyncWorkflowService.getService(access).findFirstStatusInfoByOriginalFilePathAndSourceFilePathNotEndsWith(
                             file.getAbsolutePath(),WorkflowConstants.tarContentsFileEndswith);
         	}
+        	
+        	if(createCollectionSoftlink) {
+   			 logger.debug(
+   		              "[Scheduler] Original filepath : {} , SourceFilePath: {}",  file.getAbsolutePath() , file.getPath());
+   			statusInfo =
+   		              dmeSyncWorkflowService.getService(access).findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath( doc,
+   		                   file.getPath() , file.getAbsolutePath());
+   		     }
           if(statusInfo != null) {
         	//Update the run_id and reset the retry count and errors
         	statusInfo.setRunId(runId);
@@ -1000,6 +1010,11 @@ public class DmeSyncScheduler {
 				dmeSyncMailServiceFactory.getService(doc)
 						.sendMail("HPCDME Auto Archival Result for " + doc + " - Base Path: " + syncBaseDir, emailBody);
 				logger.info("[Scheduler] No files/folders found. Shutting down the application.");
+				try {
+		              dmeSyncWorkflowRunLogService.updateWorkflowRunEnd(runId, doc, WorkflowConstants.RunStatus.SKIPPED.toString(),null);
+		            } catch (IllegalArgumentException e) {
+		              logger.warn("[Scheduler] Workflow run not found when updating run end to SKIPPED for runId: {}, doc: {}", runId, doc, e);
+		            }
 				DmeSyncApplication.shutdown();
 			}
 	    

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -755,22 +755,25 @@ public class DmeSyncScheduler {
           }
           //Modified after the last upload, so we need to re-upload
         } else {
-        	statusInfo =
-                    dmeSyncWorkflowService.getService(access).findFirstStatusInfoByOriginalFilePathOrderByStartTimestampDesc(
-                        file.getAbsolutePath());
+        	
         	if(createTarContentsFile) {
         		statusInfo =
                         dmeSyncWorkflowService.getService(access).findFirstStatusInfoByOriginalFilePathAndSourceFilePathNotEndsWith(
                             file.getAbsolutePath(),WorkflowConstants.tarContentsFileEndswith);
         	}
         	
-        	if(createCollectionSoftlink) {
+        	else if(createCollectionSoftlink) {
    			 logger.debug(
    		              "[Scheduler] Original filepath : {} , SourceFilePath: {}",  file.getAbsolutePath() , file.getPath());
    			statusInfo =
    		              dmeSyncWorkflowService.getService(access).findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath( doc,
    		                   file.getPath() , file.getAbsolutePath());
    		     }
+        	else {
+        		statusInfo =
+                        dmeSyncWorkflowService.getService(access).findFirstStatusInfoByOriginalFilePathOrderByStartTimestampDesc(
+                            file.getAbsolutePath());
+        	}
           if(statusInfo != null) {
         	//Update the run_id and reset the retry count and errors
         	statusInfo.setRunId(runId);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -118,9 +118,10 @@ public interface DmeSyncWorkflowService {
    * findTopStatusInfoByDocAndSourceFilePath
    * @param doc the doc
    * @param sourceFilePath
+   * @param OriginalFilePath
    * @return the StatusInfo object
    */
-  StatusInfo findTopStatusInfoByDocAndSourceFilePath(String doc, String sourceFilePath);
+  StatusInfo findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath(String doc, String sourceFilePath ,String originalFilePath);
 
   /**
    * findTopByDocAndSourceFilePathAndRunId

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -115,10 +115,10 @@ public interface DmeSyncWorkflowService {
   StatusInfo findTopStatusInfoByDocAndOriginalFilePathStartsWithOrderByStartTimestampDesc(String doc, String baseDir);
 
   /**
-   * findTopStatusInfoByDocAndSourceFilePath
+   * findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath
    * @param doc the doc
-   * @param sourceFilePath
-   * @param OriginalFilePath
+   * @param sourceFilePath the source file path
+   * @param originalFilePath the original file path
    * @return the StatusInfo object
    */
   StatusInfo findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath(String doc, String sourceFilePath ,String originalFilePath);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -112,8 +112,8 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   }
   
   @Override
-  public StatusInfo findTopStatusInfoByDocAndSourceFilePath(String doc, String sourceFilePath) {
-    return statusInfoDao.findTopStatusInfoByDocAndSourceFilePath(doc, sourceFilePath);
+  public StatusInfo findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath(String doc, String sourceFilePath , String originalFilePath) {
+    return statusInfoDao.findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath(doc, sourceFilePath , originalFilePath);
   }
   
   @Override

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/DefaultPathMetadataProcessorImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/DefaultPathMetadataProcessorImpl.java
@@ -35,7 +35,7 @@ public class DefaultPathMetadataProcessorImpl extends AbstractPathMetadataProces
     logger.info("[PathMetadataTask] Default getArchivePath called");
 
     if(awsFlag) {
-    	return destinationBaseDir + '/' + object.getSourceFilePath();
+    	return destinationBaseDir + '/' + object.getSourceFileName();
     }
     // For now, all files goes directly to base destination dir, under the folders from source path.
     Path baseDirPath;

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
@@ -340,8 +340,8 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 					}
 
 						StatusInfo checkForUploadedContentsFile = dmeSyncWorkflowService.getService(access)
-								.findTopStatusInfoByDocAndSourceFilePath(doc,
-										tarMappingFile.getAbsolutePath());
+								.findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath(doc,
+										tarMappingFile.getAbsolutePath() , object.getOriginalFilePath());
 
 						
 						

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarContentsFileTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarContentsFileTaskImpl.java
@@ -156,7 +156,7 @@ public class DmeSyncTarContentsFileTaskImpl extends AbstractDmeSyncTask implemen
 	private void sendContentsFileRequestToJms(File tarMappingFile, StatusInfo object) throws IOException {
 
 		StatusInfo checkForUploadedContentsFile = dmeSyncWorkflowService.getService(access)
-				.findTopStatusInfoByDocAndSourceFilePath(doc, tarMappingFile.getAbsolutePath());
+				.findTopStatusInfoByDocAndSourceFilePathAndOriginalFilePath(doc, tarMappingFile.getAbsolutePath() , object.getOriginalFilePath());
 
 		StatusInfo contentsFileRecord = null;
 
@@ -172,6 +172,7 @@ public class DmeSyncTarContentsFileTaskImpl extends AbstractDmeSyncTask implemen
 				checkForUploadedContentsFile.setError("");
 				checkForUploadedContentsFile.setRetryCount(0L);
 				checkForUploadedContentsFile.setEndWorkflow(false);
+				checkForUploadedContentsFile.setFilesize(tarMappingFile.length());
 				checkForUploadedContentsFile = dmeSyncWorkflowService.getService(access).saveStatusInfo(checkForUploadedContentsFile);
 				contentsFileRecord = checkForUploadedContentsFile;
 			}


### PR DESCRIPTION
1. GB-Omics Analysis projects is having the issues while checking the query to retrieve the record for contents file using the filter. added another filter originalFilePath to retrieve the contents file record from database.
2. GB-Omics Analysis projects collection link  for already linked flowcell.  The collection links issue is from rerun row retrieval. Our scanner is picking the file, however when retrieving the row ,  we are only checking by originalfilepath  and getting the already uploaded collection link row . I have updated filters for the collection link query using both originalfilepath and sourcefilepath.
3. Workflow Dashboard fixes : GB-OMICS data workflow has RUN_Ignored files, the complete method for the workflow run is not being populated to database in this scenario. Added the logic while there is no records for run_ignored.
4. [DMESUPPORT-204](https://tracker.nci.nih.gov/browse/DMESUPPORT-204): For the LabArchives AWS upload, we were creating folders using the bucket name, which is not needed. We should only upload the files. I changed this upload from sourcefilepath to sourcefilename. We do not have any other AWS uploads at this time. We can discuss how to handle this in upcoming meetings.
 