### PR TITLE
DMESUPPORT-203 Add Reattempts Column to Status_info Table to Track Folder/File Run Failures

### DIFF
--- a/src/main/java/gov/nih/nci/hpc/dmesync/domain/StatusInfo.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/domain/StatusInfo.java
@@ -28,6 +28,7 @@ public class StatusInfo {
   private Integer tarIndexStart ;
   private Integer tarIndexEnd ;
   private Long retryCount = 0L;
+  private Long reattempts = 0L;
   private String error;
   private String moveDataObjectOrignalPath;
   private Integer tarContentsCount;
@@ -220,6 +221,14 @@ public class StatusInfo {
   public void setEndWorkflow(Boolean endWorkflow) {
 		this.endWorkflow = endWorkflow;
 	}
+  
+  public Long getReattempts() {
+	    return reattempts;
+	  }
+
+  public void setReattempts(Long reattempts) {
+	    this.reattempts = reattempts;
+	  }
 
 @Transient
   public String getMoveDataObjectOrignalPath() {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -447,9 +447,7 @@ public class DmeSyncScheduler {
       for(StatusInfo statusInfo : statusInfoList) {
 	      if(statusInfo != null) {
 	    	//Update the run_id and reset the retry count and errors
-	    	statusInfo.setRunId(runId);
-	    	statusInfo.setError("");
-	    	statusInfo.setRetryCount(0L);
+	    	prepareForReattempt(statusInfo);
 	    	statusInfo = dmeSyncWorkflowService.getService(access).saveStatusInfo(statusInfo);
 	    	// Delete the metadata info created for this object ID
 	    	dmeSyncWorkflowService.getService(access).deleteMetadataInfoByObjectId(statusInfo.getId());
@@ -500,10 +498,7 @@ public class DmeSyncScheduler {
         for(StatusInfo statusInfo : statusInfoList) {
           if(statusInfo != null) {
             //Update the run_id and reset the retry count and errors
-            statusInfo.setRunId(runId);
-            statusInfo.setError("");
-            statusInfo.setRetryCount(0L);
-            statusInfo.setEndWorkflow(false);
+        	 prepareForReattempt(statusInfo);
             statusInfo = dmeSyncWorkflowService.getService(access).saveStatusInfo(statusInfo);
             // Delete the metadata info created for this object ID
             dmeSyncWorkflowService.getService(access).deleteMetadataInfoByObjectId(statusInfo.getId());
@@ -656,10 +651,7 @@ public class DmeSyncScheduler {
 					dmeSyncWorkflowService.getService(access).deleteTaskInfoByObjectId(statusInfo.getId());
 					// Send the incomplete objectId to the message queue for processing
 					DmeSyncMessageDto message = new DmeSyncMessageDto();
-					statusInfo.setRunId(runId);
-					statusInfo.setError("");
-					statusInfo.setRetryCount(0L);
-					statusInfo.setEndWorkflow(false);
+					prepareForReattempt(statusInfo);
 					statusInfo = dmeSyncWorkflowService.getService(access).saveStatusInfo(statusInfo);
 					message.setObjectId(statusInfo.getId());
 					sender.send(message, "inbound.queue");
@@ -776,10 +768,7 @@ public class DmeSyncScheduler {
         	}
           if(statusInfo != null) {
         	//Update the run_id and reset the retry count and errors
-        	statusInfo.setRunId(runId);
-        	statusInfo.setError("");
-        	statusInfo.setRetryCount(0L);
-        	statusInfo.setEndWorkflow(false);
+        	prepareForReattempt(statusInfo);
         	if(!file.getIsDirectory()) {
         	statusInfo.setFilesize(file.getSize());
         	}
@@ -1123,12 +1112,18 @@ public class DmeSyncScheduler {
     return (int) ((d2.getTime() - d1.getTime()) / (1000 * 60 * 60 * 24));
   }
   
+  // This metho is to prepare the status info for reattempt the upload of the failes file
+  private void prepareForReattempt(StatusInfo statusInfo) {
+	    statusInfo.setRunId(runId);
+	    statusInfo.setError("");
+	    statusInfo.setEndWorkflow(false);
+	    statusInfo.setRetryCount(0L);
+	    statusInfo.setReattempts(statusInfo.getReattempts() == null ? 1L : statusInfo.getReattempts() + 1);
+  }
+  
 	private void sendRequestToJms(StatusInfo statusInfo) {
 
-		statusInfo.setRunId(runId);
-		statusInfo.setError("");
-		statusInfo.setRetryCount(0L);
-		statusInfo.setEndWorkflow(false);
+		prepareForReattempt(statusInfo);
 		statusInfo = dmeSyncWorkflowService.getService(access).saveStatusInfo(statusInfo);
 		// Delete the metadata info created for this object ID
 		dmeSyncWorkflowService.getService(access).deleteMetadataInfoByObjectId(statusInfo.getId());
@@ -1445,10 +1440,7 @@ public class DmeSyncScheduler {
 	    int enqueued = 0;
 	    for (StatusInfo s : toRetry) {
 
-	      s.setRunId(runId);
-	      s.setError("");
-	      s.setRetryCount(0L);
-	      s.setEndWorkflow(false);
+	      prepareForReattempt(s);
 
 	      s = dmeSyncWorkflowService.getService(access).saveStatusInfo(s);
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/ExcelUtil.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/ExcelUtil.java
@@ -96,6 +96,7 @@ public class ExcelUtil {
       header.createCell(colCount++).setCellValue("DataTransferRate(Bytes/Sec)");
       header.createCell(colCount++).setCellValue("Error");
       header.createCell(colCount++).setCellValue("RetryCount");
+      header.createCell(colCount++).setCellValue("Reattempts");
       header.createCell(colCount++).setCellValue("SourceFileName");
 
       metadataInfo.sort(Comparator.comparing(MetadataInfo::getMetaDataKey));
@@ -157,6 +158,7 @@ public class ExcelUtil {
         }
         row.createCell(colCount++).setCellValue(data.getError());
         row.createCell(colCount++).setCellValue(data.getRetryCount());
+        row.createCell(colCount++).setCellValue(data.getReattempts());
         row.createCell(colCount++).setCellValue(data.getSourceFileName());
         for (String key : set) {
           boolean found = false;

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/ExcelUtil.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/ExcelUtil.java
@@ -158,7 +158,7 @@ public class ExcelUtil {
         }
         row.createCell(colCount++).setCellValue(data.getError());
         row.createCell(colCount++).setCellValue(data.getRetryCount());
-        row.createCell(colCount++).setCellValue(data.getReattempts());
+        row.createCell(colCount++).setCellValue(data.getReattempts() != null ? data.getReattempts() : 0);
         row.createCell(colCount++).setCellValue(data.getSourceFileName());
         for (String key : set) {
           boolean found = false;


### PR DESCRIPTION

Currently, there is no visibility into how many times a file or folder has failed processing.

Add a new column, Reattempts, to the status_info tableand automated report to track the number of retry attempts. Each time a file or folder is picked up for processing after a failure, increment the reattempt count. 