### PR TITLE
DMESUPPORT-207  Introduce Explicit Workflow Statuses and Prevent Rerun of Ignored Records

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>gov.nih.nci.hpc</groupId>
 	<artifactId>dme-sync</artifactId>
-	<version>2.10.0.1</version>
+	<version>2.10.1</version>
 	<name>dme-sync</name>
 	<packaging>jar</packaging>
 	<description>DME Auto-archival Workflow Application</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>gov.nih.nci.hpc</groupId>
 	<artifactId>dme-sync</artifactId>
-	<version>2.10.0</version>
+	<version>2.10.0.1</version>
 	<name>dme-sync</name>
 	<packaging>jar</packaging>
 	<description>DME Auto-archival Workflow Application</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>gov.nih.nci.hpc</groupId>
 	<artifactId>dme-sync</artifactId>
-	<version>2.10.0</version>
+	<version>2.11.0</version>
 	<name>dme-sync</name>
 	<packaging>jar</packaging>
 	<description>DME Auto-archival Workflow Application</description>

--- a/src/main/java/gov/nih/nci/hpc/dmesync/controller/RestAPIController.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/controller/RestAPIController.java
@@ -44,11 +44,11 @@ public class RestAPIController {
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
-	@GetMapping(value = "/findFirstStatusInfoByOriginalFilePathAndStatus")
+	@GetMapping(value = "/findFirstStatusInfoByOriginalFilePathAndStatusIn")
 	public StatusInfo findFirstStatusInfoByOriginalFilePathAndStatus(
-			@RequestParam(required = true) String originalFilePath, @RequestParam(required = true) String status) {
+			@RequestParam(required = true) String originalFilePath, @RequestParam(required = true) List<String> statuses) {
 		return dmeSyncWorkflowService.getService("local")
-				.findFirstStatusInfoByOriginalFilePathAndStatus(originalFilePath, status);
+				.findFirstStatusInfoByOriginalFilePathAndStatusIn(originalFilePath, statuses);
 	}
 
 	@GetMapping(value = "/findAllStatusInfoByOriginalFilePathAndStatus")

--- a/src/main/java/gov/nih/nci/hpc/dmesync/controller/RestAPIController.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/controller/RestAPIController.java
@@ -34,13 +34,13 @@ public class RestAPIController {
 
 	@PostMapping(value = "/retryWorkflow")
 	public ResponseEntity<?> retryWorkflow(@RequestBody StatusInfo statusInfo, @RequestBody Exception e) {
-		dmeSyncWorkflowService.getService("local").retryWorkflow(statusInfo, e);
+		dmeSyncWorkflowService.getService("local").retryWorkflow(statusInfo, true, e);
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 	@PostMapping(value = "/recordError")
 	public ResponseEntity<?> recordError(@RequestBody StatusInfo statusInfo) {
-		dmeSyncWorkflowService.getService("local").recordError(statusInfo);
+		dmeSyncWorkflowService.getService("local").recordError(statusInfo , true);
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/controller/RestAPIController.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/controller/RestAPIController.java
@@ -88,11 +88,11 @@ public class RestAPIController {
 				.findAllStatusInfoByOriginalFilePathAndStatusAndRunId(originalFilePath, status, runId);
 	}
 	
-	@GetMapping(value = "/findAllStatusInfoLikeOriginalFilePath")
-    public List<StatusInfo> findAllStatusInfoLikeOriginalFilePath(
+	@GetMapping(value = "/findAllFailedStatusInfoLikeOriginalFilePath")
+    public List<StatusInfo> findAllFailedStatusInfoLikeOriginalFilePath(
             @RequestParam(required = true) String originalFilePath) {
         return dmeSyncWorkflowService.getService("local")
-                .findAllStatusInfoLikeOriginalFilePath(originalFilePath);
+                .findAllFailedStatusInfoLikeOriginalFilePath(originalFilePath);
     }
 
 	@GetMapping(value = "/findCollectionNameMappingByMapKeyAndCollectionTypeAndDoc")

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -40,7 +40,7 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
    * @param originalFilePath the original file path
    * @return the list of StatusInfo objects
    */
-  @Query("select s from StatusInfo s where s.originalFilePath like ?1 and s.status is null")
+  @Query("select s from StatusInfo s where s.originalFilePath like ?1 and (s.status is null or upper(s.status) = 'FAILED')")
   List<StatusInfo> findAllLikeOriginalFilePath(String originalFilePath);
   
   /**
@@ -71,7 +71,7 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
    * @param sourceFileName the sourceFileName
    * @return the list of StatusInfo objects which matches sourceFileName  and status is null
    */
-  @Query("select s from StatusInfo s where s.originalFilePath=?1 and s.sourceFileName=?2 and s.status is null")
+  @Query("select s from StatusInfo s where s.originalFilePath=?1 and s.sourceFileName=?2 and (s.status is null or upper(s.status) = 'FAILED')")
   List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatusNull(String originalFilePath, String sourceFileName);
   
   /**

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -18,7 +18,7 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   
   /**
    * findFirstBySourceFilePathAndStatus
-   * @param sourceFilePath the original file path
+   * @param sourceFilePath the source file path
    * @param status the status
    * @return the StatusInfo object
    */

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -11,7 +11,7 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   /**
    * findFirstByOriginalFilePathAndStatusIn
    * @param originalFilePath the original file path
-   * @param statuses the statuses ;ist
+   * @param statuses the statuses
    * @return the StatusInfo object
    */
   StatusInfo findFirstByOriginalFilePathAndStatusInOrderByStartTimestampDesc(String originalFilePath,  List<String> statuses);
@@ -66,14 +66,15 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   List<StatusInfo> findAllByDocAndRunIdAndLikeOriginalFilePath(String Doc,String runId,String originalFilePath);
   
   /**
-   * findByOriginalFilePathAndSourceFileNameAndStatusFailed
+   * findByOriginalFilePathAndSourceFileNameAndStatus
    * 
    * @param originalFilePath the original file path
    * @param sourceFileName the sourceFileName
+   * @param status the status
    * @return the list of StatusInfo objects which matches sourceFileName  and status is null
    */
-  @Query("select s from StatusInfo s where s.originalFilePath=?1 and s.sourceFileName=?2 and upper(s.status) = 'FAILED'")
-  List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatusFailed(String originalFilePath, String sourceFileName);
+  @Query("select s from StatusInfo s where s.originalFilePath=?1 and s.sourceFileName=?2 and upper(s.status) =?3")
+  List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatus(String originalFilePath, String sourceFileName ,String status);
   
   /**
    * findByRunId

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -35,12 +35,12 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   List<StatusInfo> findAllByOriginalFilePathAndStatus(String originalFilePath, String status);
 
   /**
-   * findAllLikeOriginalFilePath with status failed or null
+   * findAllLikeOriginalFilePath with status failed
    * 
    * @param originalFilePath the original file path
    * @return the list of StatusInfo objects
    */
-  @Query("select s from StatusInfo s where s.originalFilePath like ?1 and (s.status is null or upper(s.status) = 'FAILED')")
+  @Query("select s from StatusInfo s where s.originalFilePath like ?1 and  upper(s.status) = 'FAILED'")
   List<StatusInfo> findAllFailedLikeOriginalFilePath(String originalFilePath);
 
   

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -17,6 +17,14 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   StatusInfo findFirstByOriginalFilePathAndStatusOrderByStartTimestampDesc(String originalFilePath, String status);
   
   /**
+   * findFirstBySourceFilePathAndStatus
+   * @param sourceFilePath the original file path
+   * @param status the status
+   * @return the StatusInfo object
+   */
+  StatusInfo findFirstBySourceFilePathAndStatusOrderByStartTimestampDesc(String sourceFilePath, String status);
+  
+  /**
    * findFirstStatusInfoByFullDestinationPathAndStatus
    * @param FullDestinationPath the full destination path
    * @param status the status

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -35,13 +35,14 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   List<StatusInfo> findAllByOriginalFilePathAndStatus(String originalFilePath, String status);
 
   /**
-   * findAllLikeOriginalFilePath
+   * findAllLikeOriginalFilePath with status failed or null
    * 
    * @param originalFilePath the original file path
    * @return the list of StatusInfo objects
    */
   @Query("select s from StatusInfo s where s.originalFilePath like ?1 and (s.status is null or upper(s.status) = 'FAILED')")
-  List<StatusInfo> findAllLikeOriginalFilePath(String originalFilePath);
+  List<StatusInfo> findAllFailedLikeOriginalFilePath(String originalFilePath);
+
   
   /**
    * findAllLikeOriginalFilePath
@@ -65,14 +66,14 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   List<StatusInfo> findAllByDocAndRunIdAndLikeOriginalFilePath(String Doc,String runId,String originalFilePath);
   
   /**
-   * findByOriginalFilePathAndSourceFileNameAndStatusNull
+   * findByOriginalFilePathAndSourceFileNameAndStatusFailed
    * 
    * @param originalFilePath the original file path
    * @param sourceFileName the sourceFileName
    * @return the list of StatusInfo objects which matches sourceFileName  and status is null
    */
-  @Query("select s from StatusInfo s where s.originalFilePath=?1 and s.sourceFileName=?2 and (s.status is null or upper(s.status) = 'FAILED')")
-  List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatusNull(String originalFilePath, String sourceFileName);
+  @Query("select s from StatusInfo s where s.originalFilePath=?1 and s.sourceFileName=?2 and upper(s.status) = 'FAILED'")
+  List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatusFailed(String originalFilePath, String sourceFileName);
   
   /**
    * findByRunId

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -9,12 +9,12 @@ import org.springframework.data.jpa.repository.Query;
 public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Long> {
 
   /**
-   * findFirstByOriginalFilePathAndStatus
+   * findFirstByOriginalFilePathAndStatusIn
    * @param originalFilePath the original file path
-   * @param status the status
+   * @param statuses the statuses ;ist
    * @return the StatusInfo object
    */
-  StatusInfo findFirstByOriginalFilePathAndStatusOrderByStartTimestampDesc(String originalFilePath, String status);
+  StatusInfo findFirstByOriginalFilePathAndStatusInOrderByStartTimestampDesc(String originalFilePath,  List<String> statuses);
   
   /**
    * findFirstStatusInfoByFullDestinationPathAndStatus

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -444,10 +444,11 @@ public class DmeSyncScheduler {
 
       List<StatusInfo> statusInfoList =
                 dmeSyncWorkflowService.getService(access).findAllStatusInfoLikeOriginalFilePath(syncBaseDir + '%');
-      for(StatusInfo statusInfo : statusInfoList) {
+       for(StatusInfo statusInfo : statusInfoList) {
 	      if(statusInfo != null) {
 	    	//Update the run_id and reset the retry count and errors
 	    	statusInfo.setRunId(runId);
+	    	statusInfo.setStatus(null);
 	    	statusInfo.setError("");
 	    	statusInfo.setRetryCount(0L);
 	    	statusInfo = dmeSyncWorkflowService.getService(access).saveStatusInfo(statusInfo);
@@ -501,6 +502,7 @@ public class DmeSyncScheduler {
           if(statusInfo != null) {
             //Update the run_id and reset the retry count and errors
             statusInfo.setRunId(runId);
+            statusInfo.setStatus(null);
             statusInfo.setError("");
             statusInfo.setRetryCount(0L);
             statusInfo.setEndWorkflow(false);
@@ -636,7 +638,8 @@ public class DmeSyncScheduler {
 				statusInfo = dmeSyncWorkflowService.getService(access)
 						.findTopStatusInfoByDocAndSourceFilePath(doc,
 								file.getAbsolutePath());
-				List<StatusInfo> statusInfoNotCompletedList = mulitpleTarRequests.stream().filter(c -> c.getStatus() == null)
+				List<StatusInfo> statusInfoNotCompletedList = mulitpleTarRequests.stream()
+						.filter(c -> WorkflowConstants.isRetryableStatus(c.getStatus()))
 						.collect(Collectors.toList());
 				if (!statusInfoNotCompletedList.isEmpty() || ((statusInfo!=null && statusInfo.getTarContentsCount()>0))) {
 					// use the same status Info rows with new Run Id for reupload
@@ -644,6 +647,7 @@ public class DmeSyncScheduler {
 						if (object != null) {
 							// Update the run_id and reset the retry count and errors
 							object.setRunId(runId);
+							object.setStatus(null);
 							object.setError("");
 							object.setRetryCount(0L);
 							object.setEndWorkflow(false);
@@ -657,6 +661,7 @@ public class DmeSyncScheduler {
 					// Send the incomplete objectId to the message queue for processing
 					DmeSyncMessageDto message = new DmeSyncMessageDto();
 					statusInfo.setRunId(runId);
+					statusInfo.setStatus(null);
 					statusInfo.setError("");
 					statusInfo.setRetryCount(0L);
 					statusInfo.setEndWorkflow(false);
@@ -761,9 +766,10 @@ public class DmeSyncScheduler {
                         dmeSyncWorkflowService.getService(access).findFirstStatusInfoByOriginalFilePathAndSourceFilePathNotEndsWith(
                             file.getAbsolutePath(),WorkflowConstants.tarContentsFileEndswith);
         	}
-          if(statusInfo != null) {
+          if(statusInfo != null && !WorkflowConstants.isIgnoredStatus(statusInfo.getStatus())) {
         	//Update the run_id and reset the retry count and errors
         	statusInfo.setRunId(runId);
+        	statusInfo.setStatus(null);
         	statusInfo.setError("");
         	statusInfo.setRetryCount(0L);
         	statusInfo.setEndWorkflow(false);
@@ -971,7 +977,7 @@ public class DmeSyncScheduler {
     statusInfo.setStartTimestamp(new Date());
     statusInfo.setDoc(doc);
     if(completed) {
-      statusInfo.setStatus("COMPLETED");
+      statusInfo.setStatus(WorkflowConstants.IGNORED);
       statusInfo.setError("specified file extension doesn't exist in correct depth");
     }
     statusInfo = dmeSyncWorkflowService.getService(access).saveStatusInfo(statusInfo);
@@ -1108,6 +1114,7 @@ public class DmeSyncScheduler {
 	private void sendRequestToJms(StatusInfo statusInfo) {
 
 		statusInfo.setRunId(runId);
+		statusInfo.setStatus(null);
 		statusInfo.setError("");
 		statusInfo.setRetryCount(0L);
 		statusInfo.setEndWorkflow(false);
@@ -1365,7 +1372,11 @@ public class DmeSyncScheduler {
 	        dmeSyncWorkflowService.getService(access).findAllByDocAndLikeOriginalFilePath(doc, syncBaseDir + "%");
 
 	    String previousRunId = baseRows.stream()
-	        .filter(s -> s != null && StringUtils.isNotBlank(s.getRunId()) && !StringUtils.equals(s.getRunId(), runId))
+	        .filter(s -> s != null
+	        		&& StringUtils.isNotBlank(s.getRunId())
+	        		&& !StringUtils.equals(s.getRunId(), runId)
+	        		&& !WorkflowConstants.isIgnoredStatus(s.getStatus())
+	        		&& !StringUtils.endsWith(s.getRunId(), WorkflowConstants.IGNORED_RUN_SUFFIX))
 	        .sorted((a, b) -> {
 	          Date ad = a.getStartTimestamp();
 	          Date bd = b.getStartTimestamp();
@@ -1397,7 +1408,7 @@ public class DmeSyncScheduler {
 
 	    List<StatusInfo> toRetry = prevRunRows.stream()
 	        .filter(s -> s != null)
-	        .filter(s -> !WorkflowConstants.COMPLETED.equalsIgnoreCase(StringUtils.defaultString(s.getStatus())))
+	        .filter(s -> WorkflowConstants.isRetryableStatus(s.getStatus()))
 	        .filter(s -> {
 	            String originalFilePath = s.getOriginalFilePath();
 	            if (StringUtils.isBlank(originalFilePath)) return false;
@@ -1428,6 +1439,7 @@ public class DmeSyncScheduler {
 	    for (StatusInfo s : toRetry) {
 
 	      s.setRunId(runId);
+	      s.setStatus(null);
 	      s.setError("");
 	      s.setRetryCount(0L);
 	      s.setEndWorkflow(false);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -612,7 +612,7 @@ public class DmeSyncScheduler {
     for (HpcPathAttributes file : files) {
 
       StatusInfo statusInfo = null;
-
+      Path fileFullPath= file.getAbsolutePath()!=null ? Paths.get(file.getAbsolutePath()):null;
       //If we need to verify previous upload, check
       if ("local".equals(verifyPrevUpload)) {
         // Checks the local db to see if it has been completed
@@ -726,6 +726,17 @@ public class DmeSyncScheduler {
 			statusInfo =
 		              dmeSyncWorkflowService.getService(access).findFirstStatusInfoByOriginalFilePathAndSourceFilePathAndStatus(
 		                  file.getAbsolutePath(), file.getPath(), "COMPLETED");
+		}
+		else if (fileFullPath!=null && Files.isSymbolicLink(fileFullPath)) {
+			Path sourceFilePath = Files.readSymbolicLink(fileFullPath);
+			if (!sourceFilePath.isAbsolute()) {
+				sourceFilePath = fileFullPath.getParent().resolve(sourceFilePath).normalize();
+			}
+			sourceFilePath = sourceFilePath.toAbsolutePath();
+			logger.debug("[Scheduler] Checking for symbolic link Completed status: Original filepath : {} , SourceFilePath: {}",
+					fileFullPath, sourceFilePath);
+			statusInfo = dmeSyncWorkflowService.getService(access)
+					.findFirstStatusInfoBySourceFilePathAndStatus(sourceFilePath.toString(), "COMPLETED");
 		}
 		else {
           statusInfo =

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -443,7 +443,7 @@ public class DmeSyncScheduler {
     try {
 
       List<StatusInfo> statusInfoList =
-                dmeSyncWorkflowService.getService(access).findAllStatusInfoLikeOriginalFilePath(syncBaseDir + '%');
+                dmeSyncWorkflowService.getService(access).findAllFailedStatusInfoLikeOriginalFilePath(syncBaseDir + '%');
        for(StatusInfo statusInfo : statusInfoList) {
 	      if(statusInfo != null) {
 	    	//Update the run_id and reset the retry count and errors
@@ -496,7 +496,7 @@ public class DmeSyncScheduler {
           queryPath = syncBaseDir + File.separatorChar + syncBaseDirFolderList.get(i);
 
         List<StatusInfo> statusInfoList =
-            dmeSyncWorkflowService.getService(access).findAllStatusInfoLikeOriginalFilePath(queryPath+'%');
+            dmeSyncWorkflowService.getService(access).findAllFailedStatusInfoLikeOriginalFilePath(queryPath+'%');
 
         for(StatusInfo statusInfo : statusInfoList) {
           if(statusInfo != null) {
@@ -992,7 +992,7 @@ public class DmeSyncScheduler {
     statusInfo.setStartTimestamp(new Date());
     statusInfo.setDoc(doc);
     if(completed) {
-      statusInfo.setStatus(WorkflowConstants.IGNORED);
+      statusInfo.setStatus(WorkflowConstants.COMPLETED);
       statusInfo.setError("specified file extension doesn't exist in correct depth");
     }
     statusInfo = dmeSyncWorkflowService.getService(access).saveStatusInfo(statusInfo);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -612,7 +612,7 @@ public class DmeSyncScheduler {
     for (HpcPathAttributes file : files) {
 
       StatusInfo statusInfo = null;
-      Path fileFullPath= file.getAbsolutePath()!=null ? Paths.get(file.getAbsolutePath()):null;
+		Path fileFullPath = file.getAbsolutePath() != null ? Paths.get(file.getAbsolutePath()) : null;
       //If we need to verify previous upload, check
       if ("local".equals(verifyPrevUpload)) {
         // Checks the local db to see if it has been completed

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -780,7 +780,7 @@ public class DmeSyncScheduler {
                             file.getAbsolutePath());
         	}
           
-          if(statusInfo != null && !WorkflowConstants.isIgnoredStatus(statusInfo.getStatus())) {
+          if(statusInfo != null && WorkflowConstants.isRetryableStatus(statusInfo.getStatus())) {
 
         	//Update the run_id and reset the retry count and errors
         	statusInfo.setRunId(runId);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -743,8 +743,8 @@ public class DmeSyncScheduler {
 		}
 		else {
           statusInfo =
-              dmeSyncWorkflowService.getService(access).findFirstStatusInfoByOriginalFilePathAndStatus(
-                  file.getAbsolutePath(), "COMPLETED");
+              dmeSyncWorkflowService.getService(access).findFirstStatusInfoByOriginalFilePathAndStatusIn(
+                  file.getAbsolutePath(), WorkflowConstants.getNoReRunStatuses());
         }
         if (statusInfo != null) {
           logger.debug(
@@ -780,7 +780,7 @@ public class DmeSyncScheduler {
                             file.getAbsolutePath());
         	}
           
-          if(statusInfo != null && WorkflowConstants.isRetryableStatus(statusInfo.getStatus())) {
+          if(statusInfo != null ) {
 
         	//Update the run_id and reset the retry count and errors
         	statusInfo.setRunId(runId);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -326,6 +326,16 @@ public interface DmeSyncWorkflowService {
    * @param List of object Ids.
    */
    void deleteStatusInfoByIds(List<Long> ids);
+   
+   
+   /**
+    * findFirstStatusInfoBySourceFilePathAndStatus
+    *
+    * @param sourceFilePath the source file path
+    * @param status the status
+    * @return the StatusInfo object
+    */
+   StatusInfo findFirstStatusInfoBySourceFilePathAndStatus(String originalFilePath, String status);
 
    StatusInfo findFirstStatusInfoByOriginalFilePathAndSourceFilePathNotEndsWith(String originalFilePath,
 		String sourceFilePath);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -96,15 +96,15 @@ public interface DmeSyncWorkflowService {
       String originalFilePath, String sourceFilePath, String status);
   
   /**
-   * findFirstStatusInfoByOriginalFilePathAndSourceFileNameAndStatusFailed
+   * findFirstStatusInfoByOriginalFilePathAndSourceFileNameAndStatus
    *
    * @param originalFilePath the original file path
    * @param sourceFileName the source file name
-   * @param status the null
+   * @param status
    * @return the StatusInfo object
    */
-  List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatusFailed(
-      String originalFilePath, String sourceFileName);
+  List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatus(
+      String originalFilePath, String sourceFileName , String status);
 
   /**
    * findTopStatusInfoByDocAndOriginalFilePathStartsWithOrderByStartTimestampDesc

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -335,7 +335,7 @@ public interface DmeSyncWorkflowService {
     * @param status the status
     * @return the StatusInfo object
     */
-   StatusInfo findFirstStatusInfoBySourceFilePathAndStatus(String originalFilePath, String status);
+   StatusInfo findFirstStatusInfoBySourceFilePathAndStatus(String sourceFilePath, String status);
 
    StatusInfo findFirstStatusInfoByOriginalFilePathAndSourceFilePathNotEndsWith(String originalFilePath,
 		String sourceFilePath);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -47,12 +47,12 @@ public interface DmeSyncWorkflowService {
       String originalFilePath, String status);
 
   /**
-   * findAllStatusInfoLikeOriginalFilePath
+   * findAllFailedStatusInfoLikeOriginalFilePath
    *
    * @param originalFilePath the original file path
-   * @return the list of StatusInfo objects
+   * @return the list of StatusInfo objects which have status failed or null
    */
-  List<StatusInfo> findAllStatusInfoLikeOriginalFilePath(
+  List<StatusInfo> findAllFailedStatusInfoLikeOriginalFilePath(
       String originalFilePath);
   
   /**
@@ -96,14 +96,14 @@ public interface DmeSyncWorkflowService {
       String originalFilePath, String sourceFilePath, String status);
   
   /**
-   * findFirstStatusInfoByOriginalFilePathAndSourceFileNameAndStatus
+   * findFirstStatusInfoByOriginalFilePathAndSourceFileNameAndStatusFailed
    *
    * @param originalFilePath the original file path
    * @param sourceFileName the source file name
    * @param status the null
    * @return the StatusInfo object
    */
-  List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatusNull(
+  List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatusFailed(
       String originalFilePath, String sourceFileName);
 
   /**

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -17,13 +17,13 @@ import gov.nih.nci.hpc.dmesync.domain.TaskInfo;
 public interface DmeSyncWorkflowService {
 
   /**
-   * findFirstStatusInfoByOriginalFilePathAndStatus
+   * findFirstStatusInfoByOriginalFilePathAndStatusIn
    *
    * @param originalFilePath the original file path
-   * @param status the status
+   * @param status the statuses list
    * @return the StatusInfo object
    */
-  StatusInfo findFirstStatusInfoByOriginalFilePathAndStatus(String originalFilePath, String status);
+  StatusInfo findFirstStatusInfoByOriginalFilePathAndStatusIn(String originalFilePath, List<String> statuses);
 
   /**
    * findFirstStatusInfoByFullDestinationPathAndStatus

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -250,14 +250,16 @@ public interface DmeSyncWorkflowService {
    * @param statusInfo the StatusInfo object
    * @param e the exception to be recorded
    */
-  public void retryWorkflow(StatusInfo statusInfo, Exception e);
+  public void retryWorkflow(StatusInfo statusInfo, boolean setStatus, Exception e);
 
   /**
    * Saves the error
    *
    * @param statusInfo the StatusInfo object
    */
-  public void recordError(StatusInfo statusInfo);
+  public void recordError(StatusInfo statusInfo , boolean setStatus);
+  
+  
 
   /**
    * findStatusInfoById

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncMailServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncMailServiceImpl.java
@@ -185,7 +185,7 @@ public class DmeSyncMailServiceImpl implements DmeSyncMailService {
       body = body.concat("<ul>"
                                   +  "<li>"+ "Total processed: " + processedCount + "</li>"
      		                      + "<li>" + "Success: " + successCount +"</li>"
-                                  + "<li>" + "Ignored: " + ignoredCount + "</li>"
+                                  + (ignoredCount > 0 ? "<li>Ignored: " + ignoredCount + "</li>" : "")
                                   + "<li>" + "Failure: " + failedCount + "</li>"  
      		                      + "<li>" + "Tar files with sizes smaller than " + ExcelUtil.humanReadableByteCount(Long.valueOf(minTarFile), true) + ": " + minTarFileCount +
      		             "</ul>");

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncMailServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncMailServiceImpl.java
@@ -156,7 +156,7 @@ public class DmeSyncMailServiceImpl implements DmeSyncMailService {
       // Check to see if any files were over the recommended size and flag if it was.
       boolean exceedsMaxRecommendedFileSize = false;
       long maxFileSize = Long.parseLong(maxRecommendedFileSize);
-      long processedCount = 0, successCount = 0, failedCount = 0;
+      long processedCount = 0, successCount = 0, failedCount = 0, ignoredCount = 0;
       for (StatusInfo info : statusInfo) {
     	  processedCount ++;
     	 
@@ -173,19 +173,22 @@ public class DmeSyncMailServiceImpl implements DmeSyncMailService {
 	    	  }
     	  }   	 
    		      	  
-    	  if (StringUtils.equals(info.getStatus(), "COMPLETED"))
-    	  {	  successCount++; }
-    	  else {
-    		  failedCount++;
-    	  }
+     	  if (WorkflowConstants.isCompletedStatus(info.getStatus())) {
+     		  successCount++;
+     	  } else if (WorkflowConstants.isIgnoredStatus(info.getStatus())) {
+     		  ignoredCount++;
+     	  } else {
+     		  failedCount++;
+     	  }
       }
        
       body = body.concat("<ul>"
                                   +  "<li>"+ "Total processed: " + processedCount + "</li>"
-    		                      + "<li>" + "Success: " + successCount +"</li>"
+     		                      + "<li>" + "Success: " + successCount +"</li>"
+                                  + "<li>" + "Ignored: " + ignoredCount + "</li>"
                                   + "<li>" + "Failure: " + failedCount + "</li>"  
-    		                      + "<li>" + "Tar files with sizes smaller than " + ExcelUtil.humanReadableByteCount(Long.valueOf(minTarFile), true) + ": " + minTarFileCount +
-    		             "</ul>");
+     		                      + "<li>" + "Tar files with sizes smaller than " + ExcelUtil.humanReadableByteCount(Long.valueOf(minTarFile), true) + ": " + minTarFileCount +
+     		             "</ul>");
      
         
       body = body.concat("<p><b><i> A Failure count of zero does not guarantee the accuracy of the metadata or the file size."
@@ -220,9 +223,9 @@ public class DmeSyncMailServiceImpl implements DmeSyncMailService {
 					// adding + 1 to include tarMapping notes,movies folder statusInfo rows
 					folder.setExpectedTars(expectedTars );
 					folder.setCreatedTars(allUploads.size());
-					folder.setUploadedTars(allUploads.stream().filter(tar -> ("COMPLETED".equals(tar.getStatus()))) 
+					folder.setUploadedTars(allUploads.stream().filter(tar -> WorkflowConstants.isCompletedStatus(tar.getStatus())) 
 							.count());
-					folder.setFailedTars(allUploads.stream().filter(tar -> (tar.getStatus() == null ))
+					folder.setFailedTars(allUploads.stream().filter(tar -> WorkflowConstants.isRetryableStatus(tar.getStatus()))
 							.count());
 					folders.add(folder);
 				}
@@ -328,58 +331,56 @@ public class DmeSyncMailServiceImpl implements DmeSyncMailService {
 
 
 					if (includedFileRecord != null 
-							&&  WorkflowConstants.COMPLETED.equals(tarRecord.getStatus())
-							&&  WorkflowConstants.COMPLETED.equals(includedFileRecord.getStatus())
-							&&  WorkflowConstants.COMPLETED.equals(excludedFileRecord.getStatus())) {
-						tarRecord.setStatus("COMPLETED");
+							&&  WorkflowConstants.isCompletedStatus(tarRecord.getStatus())
+							&&  WorkflowConstants.isCompletedStatus(includedFileRecord.getStatus())
+							&&  WorkflowConstants.isCompletedStatus(excludedFileRecord.getStatus())) {
+						tarRecord.setStatus(WorkflowConstants.COMPLETED);
 						// tarRecord.setError(""); // No error
 					} else {
-						if ( WorkflowConstants.COMPLETED.equals(tarRecord.getStatus())) {
-							if (includedFileRecord != null &&  WorkflowConstants.COMPLETED.equals(includedFileRecord.getStatus())) {
-								tarRecord.setStatus(
-										"FAILED.Excluded contents file not uploaded, only TAR file and Included contents file got uploaded.");
+						if (WorkflowConstants.isCompletedStatus(tarRecord.getStatus())) {
+							if (includedFileRecord != null && WorkflowConstants.isCompletedStatus(includedFileRecord.getStatus())) {
+								tarRecord.setStatus(WorkflowConstants.FAILED);
 								tarRecord.setError(excludedFileRecord.getError());
-							} else if ( WorkflowConstants.COMPLETED.equals(excludedFileRecord.getStatus())) {
-								tarRecord.setStatus(
-										"FAILED.Included contents file not uploaded, only TAR file and Excluded contents file got uploaded.");
+							} else if (WorkflowConstants.isCompletedStatus(excludedFileRecord.getStatus())) {
+								tarRecord.setStatus(WorkflowConstants.FAILED);
 								tarRecord.setError(includedFileRecord!=null? includedFileRecord.getError(): "Contents file has not been created, check if folder is empty.");
 
 							} else {
-								tarRecord.setStatus(
-										"FAILED.Both included and excluded contents files not uploaded, only TAR file uploaded.");
+								tarRecord.setStatus(WorkflowConstants.FAILED);
 								tarRecord.setError(includedFileRecord!=null? includedFileRecord.getError(): "Contents file has not been created, check if folder is empty.");
 
 							}
 						} else {
-							if (includedFileRecord != null &&  WorkflowConstants.COMPLETED.equals(includedFileRecord.getStatus())
-									&&  WorkflowConstants.COMPLETED.equals(excludedFileRecord.getStatus())) {
-								tarRecord.setStatus("FAILED.Tar file not uploaded, only contents files got uploaded.");
-							} else if ( WorkflowConstants.COMPLETED.equals(excludedFileRecord.getStatus())) {
-								tarRecord.setStatus(
-										"FAILED.Tar file and Included contents file not uploaded, only Excluded contents file got uploaded.");
+							tarRecord.setStatus(WorkflowConstants.FAILED);
+							if (includedFileRecord != null && WorkflowConstants.isCompletedStatus(includedFileRecord.getStatus())
+									&& WorkflowConstants.isCompletedStatus(excludedFileRecord.getStatus())) {
+								tarRecord.setError("Tar file not uploaded, only contents files got uploaded.");
+							} else if (WorkflowConstants.isCompletedStatus(excludedFileRecord.getStatus())) {
+								tarRecord.setError("Tar file and Included contents file not uploaded, only Excluded contents file got uploaded.");
 							} else if (includedFileRecord != null
-									&&  WorkflowConstants.COMPLETED.equals(includedFileRecord.getStatus())) {
-								tarRecord.setStatus(
-										"FAILED.Tar file and Excluded  contents file not uploaded, only Included contents file got uploaded.");
+									&& WorkflowConstants.isCompletedStatus(includedFileRecord.getStatus())) {
+								tarRecord.setError("Tar file and Excluded  contents file not uploaded, only Included contents file got uploaded.");
 							} else {
-								tarRecord.setStatus("FAILED.Tar file and both contents file not uploaded.");
+								tarRecord.setError("Tar file and both contents file not uploaded.");
 							}
 						}
 					}
 				} else {
 					// If excluded contents file is not set, just handle included contents file
-					if (includedFileRecord != null &&  WorkflowConstants.COMPLETED.equals(tarRecord.getStatus())
-							&&  WorkflowConstants.COMPLETED.equals(includedFileRecord.getStatus())) {
-						tarRecord.setStatus("COMPLETED");
+					if (includedFileRecord != null &&  WorkflowConstants.isCompletedStatus(tarRecord.getStatus())
+							&&  WorkflowConstants.isCompletedStatus(includedFileRecord.getStatus())) {
+						tarRecord.setStatus(WorkflowConstants.COMPLETED);
 						// tarRecord.setError(""); // No error
 					} else {
-						if ( WorkflowConstants.COMPLETED.equals(tarRecord.getStatus())) {
-							tarRecord.setStatus("FAILED.Contents file not uploaded, only TAR file uploaded.");
+						if (WorkflowConstants.isCompletedStatus(tarRecord.getStatus())) {
+							tarRecord.setStatus(WorkflowConstants.FAILED);
 							tarRecord.setError(includedFileRecord!=null ? includedFileRecord.getError(): "Contents file has not been created, check if folder is empty.");
-						} else if (includedFileRecord != null &&  WorkflowConstants.COMPLETED.equals(includedFileRecord.getStatus())) {
-							tarRecord.setStatus("FAILED.TAR file not uploaded, only contents file uploaded.");
+						} else if (includedFileRecord != null && WorkflowConstants.isCompletedStatus(includedFileRecord.getStatus())) {
+							tarRecord.setStatus(WorkflowConstants.FAILED);
+							tarRecord.setError("TAR file not uploaded, only contents file uploaded.");
 						} else {
-							tarRecord.setStatus("FAILED.TAR file and contents file not uploaded.");
+							tarRecord.setStatus(WorkflowConstants.FAILED);
+							tarRecord.setError("TAR file and contents file not uploaded.");
 						}
 					}
 				}

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowRunLogServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowRunLogServiceImpl.java
@@ -12,6 +12,7 @@ import gov.nih.nci.hpc.dmesync.domain.StatusInfo;
 import gov.nih.nci.hpc.dmesync.domain.WorkflowRunInfo;
 import gov.nih.nci.hpc.dmesync.service.DmeSyncWorkflowRunLogService;
 import gov.nih.nci.hpc.dmesync.util.ExcelUtil;
+import gov.nih.nci.hpc.dmesync.util.WorkflowConstants;
 
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -63,7 +64,7 @@ public class DmeSyncWorkflowRunLogServiceImpl implements DmeSyncWorkflowRunLogSe
 
 			List<StatusInfo> runIdRows = statusInfoDao.findByRunIdAndDoc(runId, doc);
 
-			long totalSize = runIdRows.stream().filter(f -> "COMPLETED".equalsIgnoreCase(f.getStatus()))
+			long totalSize = runIdRows.stream().filter(f -> WorkflowConstants.isCompletedStatus(f.getStatus()))
 					.map(StatusInfo::getFilesize).filter(Objects::nonNull).mapToLong(Long::longValue).sum();
 
 			Long durationMinutes = mins;

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -106,10 +106,10 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   }
   
   @Override
-  public List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatusFailed(
-      String originalFilePath, String sourceFileName) {
-    return statusInfoDao.findByOriginalFilePathAndSourceFileNameAndStatusFailed(
-        originalFilePath, sourceFileName);
+  public List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatus(
+      String originalFilePath, String sourceFileName , String status) {
+    return statusInfoDao.findByOriginalFilePathAndSourceFileNameAndStatus(
+        originalFilePath, sourceFileName , status);
   }
 
   

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -40,23 +40,23 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   }
 
   @Override
-  public void retryWorkflow(StatusInfo statusInfo, Exception e) {
+  public void retryWorkflow(StatusInfo statusInfo, boolean setStatus, Exception e) {
 	statusInfo.setError(e.getMessage());
-    if (!WorkflowConstants.isIgnoredStatus(statusInfo.getStatus())) {
-      statusInfo.setStatus(WorkflowConstants.FAILED);
-    }
-    recordError(statusInfo);
+    recordError(statusInfo , setStatus);
     // Delete the metadata info created for this object ID
     metadataInfoDao.deleteByObjectId(statusInfo.getId());
   }
 
   @Override
-  public void recordError(StatusInfo info) {
-    if (!WorkflowConstants.isIgnoredStatus(info.getStatus())) {
-      info.setStatus(WorkflowConstants.FAILED);
-    }
+  public void recordError(StatusInfo info , boolean setStatus) {
+	if (setStatus) {
+			if (!WorkflowConstants.isIgnoredStatus(info.getStatus())) {
+				info.setStatus(WorkflowConstants.FAILED);
+			}
+		}
     statusInfoDao.saveAndFlush(info);
   }
+	
 
   @Override
   public StatusInfo findFirstStatusInfoByOriginalFilePathAndStatusIn(

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -34,10 +34,6 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
 
   @Override
   public void completeWorkflow(StatusInfo statusInfo) {
-    if (!WorkflowConstants.isCompletedStatus(statusInfo.getStatus())
-        && !WorkflowConstants.isIgnoredStatus(statusInfo.getStatus())) {
-      statusInfo.setStatus(WorkflowConstants.COMPLETED);
-    }
     statusInfo.setEndTimestamp(new Date());
     statusInfoDao.saveAndFlush(statusInfo);
     taskInfoDao.deleteByObjectId(statusInfo.getId());

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -81,8 +81,8 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   }
   
   @Override
-  public List<StatusInfo> findAllStatusInfoLikeOriginalFilePath(String originalFilePath) {
-    return statusInfoDao.findAllLikeOriginalFilePath(originalFilePath);
+  public List<StatusInfo> findAllFailedStatusInfoLikeOriginalFilePath(String originalFilePath) {
+    return statusInfoDao.findAllFailedLikeOriginalFilePath(originalFilePath);
   }
   
   @Override
@@ -110,9 +110,9 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   }
   
   @Override
-  public List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatusNull(
+  public List<StatusInfo> findByOriginalFilePathAndSourceFileNameAndStatusFailed(
       String originalFilePath, String sourceFileName) {
-    return statusInfoDao.findByOriginalFilePathAndSourceFileNameAndStatusNull(
+    return statusInfoDao.findByOriginalFilePathAndSourceFileNameAndStatusFailed(
         originalFilePath, sourceFileName);
   }
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -59,9 +59,9 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   }
 
   @Override
-  public StatusInfo findFirstStatusInfoByOriginalFilePathAndStatus(
-      String originalFilePath, String status) {
-    return statusInfoDao.findFirstByOriginalFilePathAndStatusOrderByStartTimestampDesc(originalFilePath, status);
+  public StatusInfo findFirstStatusInfoByOriginalFilePathAndStatusIn(
+      String originalFilePath, List<String> statuses) {
+    return statusInfoDao.findFirstByOriginalFilePathAndStatusInOrderByStartTimestampDesc(originalFilePath, statuses);
   }
   
   @Override

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -58,6 +58,12 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   }
   
   @Override
+  public StatusInfo findFirstStatusInfoBySourceFilePathAndStatus(
+      String sourceFilePath, String status) {
+    return statusInfoDao.findFirstBySourceFilePathAndStatusOrderByStartTimestampDesc(sourceFilePath, status);
+  }
+  
+  @Override
   public StatusInfo findFirstStatusInfoByFullDestinationPathAndStatus(
       String fullDestinationPath, String status) {
     return statusInfoDao.findFirstStatusInfoByFullDestinationPathAndStatus(fullDestinationPath, status);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -19,6 +19,7 @@ import gov.nih.nci.hpc.dmesync.domain.PermissionBookmarkInfo;
 import gov.nih.nci.hpc.dmesync.domain.StatusInfo;
 import gov.nih.nci.hpc.dmesync.domain.TaskInfo;
 import gov.nih.nci.hpc.dmesync.service.DmeSyncWorkflowService;
+import gov.nih.nci.hpc.dmesync.util.WorkflowConstants;
 
 @Service("local")
 @Transactional
@@ -33,6 +34,10 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
 
   @Override
   public void completeWorkflow(StatusInfo statusInfo) {
+    if (!WorkflowConstants.isCompletedStatus(statusInfo.getStatus())
+        && !WorkflowConstants.isIgnoredStatus(statusInfo.getStatus())) {
+      statusInfo.setStatus(WorkflowConstants.COMPLETED);
+    }
     statusInfo.setEndTimestamp(new Date());
     statusInfoDao.saveAndFlush(statusInfo);
     taskInfoDao.deleteByObjectId(statusInfo.getId());
@@ -41,6 +46,9 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   @Override
   public void retryWorkflow(StatusInfo statusInfo, Exception e) {
 	statusInfo.setError(e.getMessage());
+    if (!WorkflowConstants.isIgnoredStatus(statusInfo.getStatus())) {
+      statusInfo.setStatus(WorkflowConstants.FAILED);
+    }
     recordError(statusInfo);
     // Delete the metadata info created for this object ID
     metadataInfoDao.deleteByObjectId(statusInfo.getId());
@@ -48,6 +56,9 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
 
   @Override
   public void recordError(StatusInfo info) {
+    if (!WorkflowConstants.isIgnoredStatus(info.getStatus())) {
+      info.setStatus(WorkflowConstants.FAILED);
+    }
     statusInfoDao.saveAndFlush(info);
   }
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/HiTIFMailServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/HiTIFMailServiceImpl.java
@@ -176,7 +176,7 @@ public class HiTIFMailServiceImpl implements DmeSyncMailService {
    	  body = body.concat("<ul>"
                 				+ "<li>"+ "Total processed: " + processedCount + "</li>"
                 				+ "<li>" + "Success: " + successCount +"</li>"
-                                + "<li>" + "Ignored: " + ignoredCount + "</li>"
+                				+ (ignoredCount > 0 ? "<li>Ignored: " + ignoredCount + "</li>" : "")
                                 + "<li>" + "Failure: " + failedCount + "</li>"  
                                 + "<li>" + "Tar files with sizes smaller than " + ExcelUtil.humanReadableByteCount(Long.valueOf(minTarFile), true) + ": " + minTarFileCount +
       		               "</ul>");

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/HiTIFMailServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/HiTIFMailServiceImpl.java
@@ -142,7 +142,7 @@ public class HiTIFMailServiceImpl implements DmeSyncMailService {
         // Check to see if any files were over the recommended size and flag if it was.
         boolean exceedsMaxRecommendedFileSize = false;
         long maxFileSize = Long.parseLong(maxRecommendedFileSize);
-        long processedCount = 0, successCount = 0, failedCount = 0;
+        long processedCount = 0, successCount = 0, failedCount = 0, ignoredCount = 0;
         for (StatusInfo info : statusInfo) {
       	  processedCount ++;
       	  if (info.getFilesize() > maxFileSize) {
@@ -153,8 +153,10 @@ public class HiTIFMailServiceImpl implements DmeSyncMailService {
 		    		 minTarFileCount++;	    	
 	    	  }
 	  	  }
-      	  if (StringUtils.equals(info.getStatus(), "COMPLETED"))
+      	  if (WorkflowConstants.isCompletedStatus(info.getStatus()))
       		  successCount++;
+      	  else if (WorkflowConstants.isIgnoredStatus(info.getStatus()))
+      		  ignoredCount++;
       	  else
       		  failedCount++;
         }
@@ -171,9 +173,10 @@ public class HiTIFMailServiceImpl implements DmeSyncMailService {
          // helper.setSubject("DME Auto Archival Result for HiTIF - Run_ID: " + runId + " - Base Path:  " + syncBaseDir + " [to: " + allEmails + "]");
      	  helper.setSubject("DME Auto Archival " + subject + " for HiTIF - Run_ID: " + runId + " - Base Path:  " + syncBaseDir + " [to: " + allEmails + "]");
         }
-  	  body = body.concat("<ul>"
+   	  body = body.concat("<ul>"
                 				+ "<li>"+ "Total processed: " + processedCount + "</li>"
                 				+ "<li>" + "Success: " + successCount +"</li>"
+                                + "<li>" + "Ignored: " + ignoredCount + "</li>"
                                 + "<li>" + "Failure: " + failedCount + "</li>"  
                                 + "<li>" + "Tar files with sizes smaller than " + ExcelUtil.humanReadableByteCount(Long.valueOf(minTarFile), true) + ": " + minTarFileCount +
       		               "</ul>");

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/ExcelUtil.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/ExcelUtil.java
@@ -120,7 +120,7 @@ public class ExcelUtil {
         row.createCell(colCount++).setCellValue(data.getFullDestinationPath());
         row.createCell(colCount++).setCellValue(data.getFilesize());
         row.createCell(colCount++).setCellValue(humanReadableByteCount(data.getFilesize().doubleValue(), true));
-        row.createCell(colCount++).setCellValue(data.getStatus());
+        row.createCell(colCount++).setCellValue(WorkflowConstants.getDisplayStatus(data.getStatus()));
         if (data.getTarContentsCount() != null) {
 			row.createCell(colCount++).setCellValue(data.getTarContentsCount());
 		} else {
@@ -134,7 +134,7 @@ public class ExcelUtil {
           row.createCell(colCount++).setCellValue("");
         }
         row.createCell(colCount++).setCellValue(sdf.format(data.getStartTimestamp()));
-        if ("COMPLETED".equalsIgnoreCase(data.getStatus())
+        if (WorkflowConstants.isCompletedStatus(data.getStatus())
             && data.getUploadStartTimestamp() != null) {
           if (data.getEndTimestamp() == null) data.setEndTimestamp(new Date());
           row.createCell(colCount++).setCellValue(sdf.format(data.getEndTimestamp()));

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/TarUtil.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/TarUtil.java
@@ -64,10 +64,10 @@ public class TarUtil {
  * @throws Exception 
    */
   public static void targz(String name, List<String> excludeFolders, boolean ignoreBrokenLinksInTar, File... files) throws Exception {
-	  Set<Path> seenRealPaths = new HashSet<>();
+	  Set<Path> realPathsIncludedInTar = new HashSet<>();
 	  try (TarArchiveOutputStream out = getTarGzArchiveOutputStream(name); ) {
       for (File file : files) {
-        addToArchive(out, file, ".", excludeFolders, ignoreBrokenLinksInTar , seenRealPaths);
+        addToArchive(out, file, ".", excludeFolders, ignoreBrokenLinksInTar , realPathsIncludedInTar);
       }
     }
   }

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/TarUtil.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/TarUtil.java
@@ -47,9 +47,10 @@ public class TarUtil {
  * @throws Exception 
    */
   public static void tar(String name, List<String> excludeFolders, boolean ignoreBrokenLinksInTar, File... files) throws Exception {
-    try (TarArchiveOutputStream out = getTarArchiveOutputStream(name); ) {
+	  Set<Path> seenRealPaths = new HashSet<>();
+	  try (TarArchiveOutputStream out = getTarArchiveOutputStream(name); ) {
       for (File file : files) {
-        addToArchive(out, file, ".", excludeFolders, ignoreBrokenLinksInTar);
+        addToArchive(out, file, ".", excludeFolders, ignoreBrokenLinksInTar , seenRealPaths);
       }
     }
   }
@@ -63,9 +64,10 @@ public class TarUtil {
  * @throws Exception 
    */
   public static void targz(String name, List<String> excludeFolders, boolean ignoreBrokenLinksInTar, File... files) throws Exception {
-    try (TarArchiveOutputStream out = getTarGzArchiveOutputStream(name); ) {
+	  Set<Path> seenRealPaths = new HashSet<>();
+	  try (TarArchiveOutputStream out = getTarGzArchiveOutputStream(name); ) {
       for (File file : files) {
-        addToArchive(out, file, ".", excludeFolders, ignoreBrokenLinksInTar);
+        addToArchive(out, file, ".", excludeFolders, ignoreBrokenLinksInTar , seenRealPaths);
       }
     }
   }
@@ -266,46 +268,95 @@ public class TarUtil {
 	    return new GzipCompressorOutputStream(bufferedOutputStream);
 	  }
 
-  private static void addToArchive(TarArchiveOutputStream out, File file, String dir, List<String> excludeFolders, boolean ignoreBrokenLinksInTar)
-      throws Exception {
-    String entry = dir + File.separator + file.getName();
-    Path path = Paths.get(file.getAbsolutePath());
-    if (file.isFile()) {
-      out.putArchiveEntry(new TarArchiveEntry(file, entry));
-      try (FileInputStream in = new FileInputStream(file)) {
-        IOUtils.copy(in, out);
-      }
-      out.closeArchiveEntry();
-    } else if(file.isDirectory() && excludeFolders != null && !excludeFolders.isEmpty() && excludeFolders.contains(file.getName())) {
-      logger.info("{} is excluded for tar", file.getName());
-    } else if(file.isDirectory()) {
-      if (!Files.isReadable(Paths.get(file.getAbsolutePath()))) {
-        throw new Exception("No Read permission to " + file.getAbsolutePath());
-      }
-      File[] children = file.listFiles();
-      if (children != null) {
-        for (File child : children) {
-          addToArchive(out, child, entry, excludeFolders, ignoreBrokenLinksInTar);
-        }
-      }
-	} else if (!ignoreBrokenLinksInTar && Files.isSymbolicLink(path)) {
-		/* When ignore Broken link is not set, workflow will throw the expection and error is recorded in DB and automated report
-		 */
-		Path target = Files.readSymbolicLink(path);
-		Path resolved = path.getParent().resolve(target).normalize();
-		if (!Files.exists(resolved))
-			throw new Exception(
-					"Broken symbolic link detected: " + resolved + " (target does not exist)");
-		else if (!Files.isReadable(resolved))
-			throw new Exception(
-					"Broken symbolic link detected: " + resolved + " (target is inaccessible)");
-	} else {
-		/* When ignore Broken link is set , workflow ignores the broken links and if exclude contents file is also set then these broken links 
-		 * will be added to excluded contents file and uploaded to DME
-		 */
-      logger.error("{} is not supported", file.getName());
-    }
+  private static void addToArchive(TarArchiveOutputStream out, File file, String dir, List<String> excludeFolders,
+				boolean ignoreBrokenLinksInTar, Set<Path> seenRealPaths) throws Exception {
+
+		String entry = dir + File.separator + file.getName();
+		Path path = file.toPath();
+
+		if (Files.isSymbolicLink(path)) {
+			Path resolvedPath;
+			try {
+				resolvedPath = path.toRealPath();
+			} catch (IOException e) {
+				if (ignoreBrokenLinksInTar) {
+					logger.warn("Skipping broken symbolic link {}", path);
+					return;
+				}
+				throw new Exception("Broken symbolic link detected: " + path, e);
+			}
+
+			if (!Files.exists(resolvedPath) || !Files.isReadable(resolvedPath)) {
+				if (ignoreBrokenLinksInTar) {
+					logger.warn("Skipping unreadable symbolic link target {} -> {}", path, resolvedPath);
+					return;
+				}
+				throw new Exception("Broken symbolic link detected: " + resolvedPath + " (target is inaccessible)");
+			}
+
+			if (seenRealPaths.contains(resolvedPath)) {
+				logger.info("Skipping symbolic link {} because target is already included: {}", path, resolvedPath);
+				return;
+			}
+
+			if (Files.isDirectory(resolvedPath)) {
+				if (excludeFolders != null && !excludeFolders.isEmpty() && excludeFolders.contains(file.getName())) {
+					logger.info("{} is excluded for tar", file.getName());
+					return;
+				}
+
+				if (!Files.isReadable(resolvedPath)) {
+					throw new Exception("No Read permission to " + resolvedPath);
+				}
+
+				seenRealPaths.add(resolvedPath);
+
+				File[] children = resolvedPath.toFile().listFiles();
+				if (children != null) {
+					for (File child : children) {
+						addToArchive(out, child, entry, excludeFolders, ignoreBrokenLinksInTar, seenRealPaths);
+					}
+				}
+				return;
+			}
+
+			seenRealPaths.add(resolvedPath);
+			out.putArchiveEntry(new TarArchiveEntry(resolvedPath.toFile(), entry));
+			try (FileInputStream in = new FileInputStream(resolvedPath.toFile())) {
+				IOUtils.copy(in, out);
+			}
+			out.closeArchiveEntry();
+			return;
+		}
+
+		if (file.isFile()) {
+			Path realPath = path.toRealPath();
+			seenRealPaths.add(realPath);
+
+			out.putArchiveEntry(new TarArchiveEntry(file, entry));
+			try (FileInputStream in = new FileInputStream(file)) {
+				IOUtils.copy(in, out);
+			}
+			out.closeArchiveEntry();
+		} else if (file.isDirectory() && excludeFolders != null && !excludeFolders.isEmpty()
+				&& excludeFolders.contains(file.getName())) {
+			logger.info("{} is excluded for tar", file.getName());
+		} else if (file.isDirectory()) {
+			if (!Files.isReadable(path)) {
+				throw new Exception("No Read permission to " + file.getAbsolutePath());
+			}
+			File[] children = file.listFiles();
+			if (children != null) {
+				for (File child : children) {
+					addToArchive(out, child, entry, excludeFolders, ignoreBrokenLinksInTar, seenRealPaths);
+				}
+			}
+		} else {
+			logger.error("{} is not supported", file.getName());
+		}
   }
+  
+  
   
   public static long getDirectorySize(Path dir, List<String> excludeFolders) throws IOException {
 		final long[] size = { 0 };
@@ -501,4 +552,5 @@ public class TarUtil {
       // Check if the sourceDirLeafNode matches the generated regex
       return sourceDirLeafNode.matches(regex);
   }
+  
 }

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/TarUtil.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/TarUtil.java
@@ -47,10 +47,10 @@ public class TarUtil {
  * @throws Exception 
    */
   public static void tar(String name, List<String> excludeFolders, boolean ignoreBrokenLinksInTar, File... files) throws Exception {
-	  Set<Path> seenRealPaths = new HashSet<>();
+	  Set<Path> realPathsIncludedInTar = new HashSet<>();
 	  try (TarArchiveOutputStream out = getTarArchiveOutputStream(name); ) {
       for (File file : files) {
-        addToArchive(out, file, ".", excludeFolders, ignoreBrokenLinksInTar , seenRealPaths);
+        addToArchive(out, file, ".", excludeFolders, ignoreBrokenLinksInTar , realPathsIncludedInTar);
       }
     }
   }
@@ -269,7 +269,7 @@ public class TarUtil {
 	  }
 
   private static void addToArchive(TarArchiveOutputStream out, File file, String dir, List<String> excludeFolders,
-				boolean ignoreBrokenLinksInTar, Set<Path> seenRealPaths) throws Exception {
+				boolean ignoreBrokenLinksInTar, Set<Path> realPathsIncludedInTar) throws Exception {
 
 		String entry = dir + File.separator + file.getName();
 		Path path = file.toPath();
@@ -294,7 +294,7 @@ public class TarUtil {
 				throw new Exception("Broken symbolic link detected: " + resolvedPath + " (target is inaccessible)");
 			}
 
-			if (seenRealPaths.contains(resolvedPath)) {
+			if (realPathsIncludedInTar.contains(resolvedPath)) {
 				logger.info("Skipping symbolic link {} because target is already included: {}", path, resolvedPath);
 				return;
 			}
@@ -309,18 +309,18 @@ public class TarUtil {
 					throw new Exception("No Read permission to " + resolvedPath);
 				}
 
-				seenRealPaths.add(resolvedPath);
+				realPathsIncludedInTar.add(resolvedPath);
 
 				File[] children = resolvedPath.toFile().listFiles();
 				if (children != null) {
 					for (File child : children) {
-						addToArchive(out, child, entry, excludeFolders, ignoreBrokenLinksInTar, seenRealPaths);
+						addToArchive(out, child, entry, excludeFolders, ignoreBrokenLinksInTar, realPathsIncludedInTar);
 					}
 				}
 				return;
 			}
 
-			seenRealPaths.add(resolvedPath);
+			realPathsIncludedInTar.add(resolvedPath);
 			out.putArchiveEntry(new TarArchiveEntry(resolvedPath.toFile(), entry));
 			try (FileInputStream in = new FileInputStream(resolvedPath.toFile())) {
 				IOUtils.copy(in, out);
@@ -331,7 +331,7 @@ public class TarUtil {
 
 		if (file.isFile()) {
 			Path realPath = path.toRealPath();
-			seenRealPaths.add(realPath);
+			realPathsIncludedInTar.add(realPath);
 
 			out.putArchiveEntry(new TarArchiveEntry(file, entry));
 			try (FileInputStream in = new FileInputStream(file)) {
@@ -348,7 +348,7 @@ public class TarUtil {
 			File[] children = file.listFiles();
 			if (children != null) {
 				for (File child : children) {
-					addToArchive(out, child, entry, excludeFolders, ignoreBrokenLinksInTar, seenRealPaths);
+					addToArchive(out, child, entry, excludeFolders, ignoreBrokenLinksInTar, realPathsIncludedInTar);
 				}
 			}
 		} else {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/WorkflowConstants.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/WorkflowConstants.java
@@ -1,5 +1,7 @@
 package gov.nih.nci.hpc.dmesync.util;
 
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 
 public class WorkflowConstants {
@@ -51,5 +53,9 @@ public class WorkflowConstants {
 		return runId + IGNORED_RUN_SUFFIX;
 	}
 	
+	public static List<String> getNoReRunStatuses(){
+	   List<String> statuses = List.of(COMPLETED, IGNORED);
+       return statuses;
+	}
 
 }

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/WorkflowConstants.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/WorkflowConstants.java
@@ -1,14 +1,56 @@
 package gov.nih.nci.hpc.dmesync.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class WorkflowConstants {
 	
 	public static final String tarContentsFileEndswith ="_TarContentsFile.txt";
 	public static final String tarExcludedContentsFileEndswith ="_TarExcludedContentsFile.txt";
 	public static final String COMPLETED ="COMPLETED";
+	public static final String FAILED ="FAILED";
+	public static final String IGNORED ="IGNORED";
 	public static final String IGNORED_RUN_SUFFIX="_IGNORED";
 	public enum RunStatus {
 		  RUNNING, SUCCEEDED, FAILED, SKIPPED, CANCELLED
 		}
+
+	public static boolean isCompletedStatus(String status) {
+		return COMPLETED.equalsIgnoreCase(StringUtils.trimToEmpty(status));
+	}
+
+	public static boolean isFailedStatus(String status) {
+		String normalizedStatus = StringUtils.trimToEmpty(status);
+		return FAILED.equalsIgnoreCase(normalizedStatus)
+				|| StringUtils.startsWithIgnoreCase(normalizedStatus, FAILED + ".");
+	}
+
+	public static boolean isIgnoredStatus(String status) {
+		return IGNORED.equalsIgnoreCase(StringUtils.trimToEmpty(status));
+	}
+
+	public static boolean isRetryableStatus(String status) {
+		return StringUtils.isBlank(status) || isFailedStatus(status);
+	}
+
+	public static String getDisplayStatus(String status) {
+		if (isCompletedStatus(status)) {
+			return COMPLETED;
+		}
+		if (isIgnoredStatus(status)) {
+			return IGNORED;
+		}
+		if (isFailedStatus(status) || StringUtils.isBlank(status)) {
+			return FAILED;
+		}
+		return status;
+	}
+
+	public static String toIgnoredRunId(String runId) {
+		if (StringUtils.endsWith(runId, IGNORED_RUN_SUFFIX)) {
+			return runId;
+		}
+		return runId + IGNORED_RUN_SUFFIX;
+	}
 	
 
 }

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/WorkflowConstants.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/WorkflowConstants.java
@@ -20,8 +20,7 @@ public class WorkflowConstants {
 
 	public static boolean isFailedStatus(String status) {
 		String normalizedStatus = StringUtils.trimToEmpty(status);
-		return FAILED.equalsIgnoreCase(normalizedStatus)
-				|| StringUtils.startsWithIgnoreCase(normalizedStatus, FAILED + ".");
+		return FAILED.equalsIgnoreCase(normalizedStatus);
 	}
 
 	public static boolean isIgnoredStatus(String status) {
@@ -29,7 +28,7 @@ public class WorkflowConstants {
 	}
 
 	public static boolean isRetryableStatus(String status) {
-		return StringUtils.isBlank(status) || isFailedStatus(status);
+		return isFailedStatus(status);
 	}
 
 	public static String getDisplayStatus(String status) {
@@ -39,7 +38,7 @@ public class WorkflowConstants {
 		if (isIgnoredStatus(status)) {
 			return IGNORED;
 		}
-		if (isFailedStatus(status) || StringUtils.isBlank(status)) {
+		if (isFailedStatus(status)) {
 			return FAILED;
 		}
 		return status;

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/GBOmicsPathMetadataProcessorImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/GBOmicsPathMetadataProcessorImpl.java
@@ -123,7 +123,7 @@ public class GBOmicsPathMetadataProcessorImpl extends AbstractPathMetadataProces
 						//This path is not in the master file, so log the path and complete the workflow
 						logger.info("No need to upload file : {}", object.getOriginalFilePath());
 						// update the current status info row as completed so this workflow is completed and next task won't be processed.
-						object.setStatus(WorkflowConstants.IGNORED);
+						object.setStatus(WorkflowConstants.FAILED);
 						object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
 						object.setEndWorkflow(true);
 						object.setError("No need to upload");
@@ -147,7 +147,7 @@ public class GBOmicsPathMetadataProcessorImpl extends AbstractPathMetadataProces
 			String projectTitle = getAttrValueWithExactKey(projectCollectionName, "project_title");
 			if(projectTitle == null) {
 				logger.info("No need to upload file : {}", object.getOriginalFilePath());
-				object.setStatus(WorkflowConstants.IGNORED);
+				object.setStatus(WorkflowConstants.FAILED);
 				object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
 				object.setEndWorkflow(true);
 				object.setError("No need to upload yet");

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/GBOmicsPathMetadataProcessorImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/GBOmicsPathMetadataProcessorImpl.java
@@ -107,7 +107,7 @@ public class GBOmicsPathMetadataProcessorImpl extends AbstractPathMetadataProces
 				// This Archive column is not Yes in the master file, so dataset is not ready to upload, log the path and complete the workflow
 				logger.info("No need to upload file : {} Archive column is {} ", object.getOriginalFilePath(), archiveStatus);
 				// update the current status info row as completed so this workflow is complete and next task won't be processed.
-				object.setStatus(WorkflowConstants.IGNORED);
+				object.setStatus(WorkflowConstants.FAILED);
 				object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
 				object.setEndWorkflow(true);
 				object.setError("No need to upload, Archive column is set to "+ archiveStatus);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/GBOmicsPathMetadataProcessorImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/GBOmicsPathMetadataProcessorImpl.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import gov.nih.nci.hpc.dmesync.domain.StatusInfo;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncMappingException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncWorkflowException;
+import gov.nih.nci.hpc.dmesync.util.WorkflowConstants;
 import gov.nih.nci.hpc.dmesync.workflow.DmeSyncPathMetadataProcessor;
 import gov.nih.nci.hpc.domain.metadata.HpcBulkMetadataEntries;
 import gov.nih.nci.hpc.domain.metadata.HpcBulkMetadataEntry;
@@ -106,7 +107,8 @@ public class GBOmicsPathMetadataProcessorImpl extends AbstractPathMetadataProces
 				// This Archive column is not Yes in the master file, so dataset is not ready to upload, log the path and complete the workflow
 				logger.info("No need to upload file : {} Archive column is {} ", object.getOriginalFilePath(), archiveStatus);
 				// update the current status info row as completed so this workflow is complete and next task won't be processed.
-				object.setRunId(object.getRunId() + "_IGNORED");
+				object.setStatus(WorkflowConstants.IGNORED);
+				object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
 				object.setEndWorkflow(true);
 				object.setError("No need to upload, Archive column is set to "+ archiveStatus);
 				object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
@@ -121,7 +123,8 @@ public class GBOmicsPathMetadataProcessorImpl extends AbstractPathMetadataProces
 						//This path is not in the master file, so log the path and complete the workflow
 						logger.info("No need to upload file : {}", object.getOriginalFilePath());
 						// update the current status info row as completed so this workflow is completed and next task won't be processed.
-						object.setRunId(object.getRunId() + "_IGNORED");
+						object.setStatus(WorkflowConstants.IGNORED);
+						object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
 						object.setEndWorkflow(true);
 						object.setError("No need to upload");
 						object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
@@ -144,7 +147,8 @@ public class GBOmicsPathMetadataProcessorImpl extends AbstractPathMetadataProces
 			String projectTitle = getAttrValueWithExactKey(projectCollectionName, "project_title");
 			if(projectTitle == null) {
 				logger.info("No need to upload file : {}", object.getOriginalFilePath());
-				object.setRunId(object.getRunId() + "_IGNORED");
+				object.setStatus(WorkflowConstants.IGNORED);
+				object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
 				object.setEndWorkflow(true);
 				object.setError("No need to upload yet");
 				object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -50,6 +50,7 @@ import gov.nih.nci.hpc.dmesync.domain.StatusInfo;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncMappingException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncVerificationException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncWorkflowException;
+import gov.nih.nci.hpc.dmesync.util.WorkflowConstants;
 import gov.nih.nci.hpc.dmesync.workflow.DmeSyncTask;
 import gov.nih.nci.hpc.domain.datatransfer.HpcMultipartUpload;
 import gov.nih.nci.hpc.domain.datatransfer.HpcUploadPartETag;
@@ -220,10 +221,20 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 		    logger.info("[{}] Checking if the previous uploaded file matches the checksum and size {}", super.getTaskName());
 
 			StatusInfo uploadedFileInfo = dmeSyncWorkflowService.getService(access)
-					.findFirstStatusInfoByFullDestinationPathAndStatus(object.getFullDestinationPath(), "COMPLETED");
+					.findFirstStatusInfoByFullDestinationPathAndStatus(object.getFullDestinationPath(), WorkflowConstants.COMPLETED);
 			if (uploadedFileInfo != null) {
-				if (!StringUtils.equalsIgnoreCase(object.getChecksum(), uploadedFileInfo.getChecksum())
-						&& object.getFilesize() != uploadedFileInfo.getFilesize()) {
+				boolean checksumMatches = StringUtils.equalsIgnoreCase(object.getChecksum(), uploadedFileInfo.getChecksum());
+				boolean filesizeMatches = object.getFilesize() != null
+						&& object.getFilesize().equals(uploadedFileInfo.getFilesize());
+				if (checksumMatches && filesizeMatches) {
+					object.setStatus(WorkflowConstants.IGNORED);
+					object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
+					object.setEndWorkflow(true);
+					object.setError("No upload needed because the archived file already matches checksum and file size.");
+					dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
+					return object;
+				}
+				if (!checksumMatches || !filesizeMatches) {
 					 // get file last modified date to MMddyyyy
 		            File newFile = new File(object.getOriginalFilePath());
 		            long lastModifiedMillis = newFile.lastModified();

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -228,11 +228,8 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 						&& object.getFilesize().equals(uploadedFileInfo.getFilesize());
 				if (checksumMatches && filesizeMatches) {
 					object.setStatus(WorkflowConstants.IGNORED);
-					object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
-					object.setEndWorkflow(true);
-					object.setError("No upload needed because the archived file already matches checksum and file size.");
 					dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
-					return object;
+					throw new DmeSyncWorkflowException(errorResponse.getMessage());
 				}
 				if (!checksumMatches || !filesizeMatches) {
 					 // get file last modified date to MMddyyyy

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -244,9 +244,12 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 
 				}
 			} else {
-				// This scenario should happen when DME archive indicates the file is already archived, but no matching Completed database record was found for the file. 
+				/* This scenario should happen when DME archive indicates the file is already archived, but no matching Completed database record was found for the file. 
+				 * Manual verification of file is needed when this error happens.
+				 */
 				String msg = messageService.get("MISMATCH_STATUS_MSG");
-				logger.error("[{}] DME archive indicates the upload is already archived, but no matching Completed database record was found {}", super.getTaskName(), msg);
+				logger.error("[{}] DME archive indicates the upload is already archived, but no matching Completed database record was found ; "
+						+ " Manual verification of file is needed when this error happens {}", super.getTaskName(), msg);
 			    throw new DmeSyncVerificationException(msg);
 			}
 		}

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -244,8 +244,9 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 
 				}
 			} else {
+				// This scenario should happen when DME archive indicates the file is already archived, but no matching Completed database record was found for the file. 
 				String msg = messageService.get("MISMATCH_STATUS_MSG");
-				logger.error("[{}] {}", super.getTaskName(), msg);
+				logger.error("[{}] DME archive indicates the upload is already archived, but no matching Completed database record was found {}", super.getTaskName(), msg);
 			    throw new DmeSyncVerificationException(msg);
 			}
 		}

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -51,6 +51,7 @@ import gov.nih.nci.hpc.dmesync.exception.DmeSyncMappingException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncVerificationException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncWorkflowException;
 import gov.nih.nci.hpc.dmesync.workflow.DmeSyncTask;
+import gov.nih.nci.hpc.dmesync.workflow.MessageService;
 import gov.nih.nci.hpc.domain.datatransfer.HpcMultipartUpload;
 import gov.nih.nci.hpc.domain.datatransfer.HpcUploadPartETag;
 import gov.nih.nci.hpc.domain.datatransfer.HpcUploadPartURL;
@@ -71,6 +72,7 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
   @Autowired private RestTemplateFactory restTemplateFactory;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private DmeSyncDeleteDataObject dmeSyncDeleteDataObject;
+  @Autowired private MessageService messageService;
 
   @Value("${hpc.server.url}")
   private String serverUrl;
@@ -241,6 +243,10 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 					return object;
 
 				}
+			} else {
+				String msg = messageService.get("MISMATCH_STATUS");
+				logger.error("[{}] {}", super.getTaskName(), msg);
+			    throw new DmeSyncVerificationException(msg);
 			}
 		}
 	    logger.error("[{}] {}", super.getTaskName(), errorResponse.getStackTrace());

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -227,9 +227,10 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 				boolean filesizeMatches = object.getFilesize() != null
 						&& object.getFilesize().equals(uploadedFileInfo.getFilesize());
 				if (checksumMatches && filesizeMatches) {
+					logger.info("[{}] Setting Status to Ignored because the checksum and file size matches with the file in DME {}",
+							super.getTaskName(), object.getFullDestinationPath());
 					object.setStatus(WorkflowConstants.IGNORED);
 					dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
-					throw new DmeSyncWorkflowException(errorResponse.getMessage());
 				}
 				if (!checksumMatches || !filesizeMatches) {
 					 // get file last modified date to MMddyyyy

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -222,7 +222,7 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 
 			StatusInfo uploadedFileInfo = dmeSyncWorkflowService.getService(access)
 					.findFirstStatusInfoByFullDestinationPathAndStatus(object.getFullDestinationPath(), WorkflowConstants.COMPLETED);
-			if (uploadedFileInfo != null) {
+			if (uploadedFileInfo != null && !StringUtils.isEmpty(uploadedFileInfo.getChecksum())) {
 				boolean checksumMatches = StringUtils.equalsIgnoreCase(object.getChecksum(), uploadedFileInfo.getChecksum());
 				boolean filesizeMatches = object.getFilesize() != null
 						&& object.getFilesize().equals(uploadedFileInfo.getFilesize());

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -244,7 +244,7 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 
 				}
 			} else {
-				String msg = messageService.get("MISMATCH_STATUS");
+				String msg = messageService.get("MISMATCH_STATUS_MSG");
 				logger.error("[{}] {}", super.getTaskName(), msg);
 			    throw new DmeSyncVerificationException(msg);
 			}

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
@@ -230,8 +230,8 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 											super.getTaskName(), tarFileName, recordForUploadedTar.getId(),
 											recordForUploadedTar.getStatus());
 									List<StatusInfo> duplicateRows = dmeSyncWorkflowService.getService(access)
-											.findByOriginalFilePathAndSourceFileNameAndStatusFailed(object.getOriginalFilePath(),
-													tarFileName);
+											.findByOriginalFilePathAndSourceFileNameAndStatus(object.getOriginalFilePath(),
+													tarFileName , WorkflowConstants.FAILED);
 									if (!duplicateRows.isEmpty()) {
 										List<Long> objectIds = duplicateRows.stream().map(StatusInfo::getId)
 												.collect(Collectors.toList());

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
@@ -318,8 +318,8 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 					if (totalFilesInTars != files.length) {
 						object.setError((" Files in original folder " + files.length
 								+ " doesn't match the files in multiple tars requests " + totalFilesInTars));
+						object.setStatus(WorkflowConstants.FAILED);
 						dmeSyncWorkflowService.getService(access).recordError(object);
-						object.setStatus(null);
 						throw new DmeSyncVerificationException((" Files in original folder " + files.length
 								+ " doesn't match the files in multiple created tars " + totalFilesInTars));
 					} 
@@ -327,7 +327,7 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 						// verify if all the tar requests are inserted in status_info table.If not throw the exception
 						object.setError((" Expected tar creation Requests " + expectedTarRequests
 								+ " doesn't match the creation requests in DB " + totalTarsRequests));
-						object.setStatus(null);
+						object.setStatus(WorkflowConstants.FAILED);
 						dmeSyncWorkflowService.getService(access).recordError(object);
 						throw new DmeSyncVerificationException((" Expected tar creation Requests " + expectedTarRequests
 								+ " doesn't match the creation requests in DB " + totalTarsRequests));
@@ -359,6 +359,10 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 							  // If the contents file is not uploaded and all the tars are uploaded, so enqueing the contents file 
 							logger.info("[{}]Enqueuing the existing contents file upload request {}", super.getTaskName(),
 										tarMappingFile.getName());
+							checkForUploadedContentsFile.setStatus(null);
+							checkForUploadedContentsFile.setError("");
+							checkForUploadedContentsFile.setRetryCount(0L);
+							checkForUploadedContentsFile.setEndWorkflow(false);
 							checkForUploadedContentsFile.setFilesize(tarMappingFile.length());
 							checkForUploadedContentsFile = dmeSyncWorkflowService.getService(access).saveStatusInfo(checkForUploadedContentsFile);
 							enqueueRequestToJms(checkForUploadedContentsFile);
@@ -385,8 +389,8 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 								object.getTarContentsCount());
 						
 						// update the current status info row as completed so this workflow is completed and next task won't be processed.
-						object.setStatus("COMPLETED");
-						object.setRunId(object.getRunId() + WorkflowConstants.IGNORED_RUN_SUFFIX);
+						object.setStatus(WorkflowConstants.IGNORED);
+						object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
 						object.setEndWorkflow(true);
 						object.setSourceFilePath(object.getOriginalFilePath());
 						object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
@@ -444,6 +448,7 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 		statusInfo.setSourceFilePath(object.getOriginalFilePath());
 		statusInfo.setFilesize(0L);
 		statusInfo.setError(error);
+		statusInfo.setStatus(WorkflowConstants.FAILED);
 
 		statusInfo = dmeSyncWorkflowService.getService(access).saveStatusInfo(statusInfo);
 
@@ -586,8 +591,8 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 		if (coveredFolders != expectedCovered) {
 			object.setError("Grouped site folder coverage mismatch: covered=" + coveredFolders + " expected="
 					+ expectedCovered);
+			object.setStatus(WorkflowConstants.FAILED);
 			dmeSyncWorkflowService.getService(access).recordError(object);
-			object.setStatus(null);
 			throw new DmeSyncVerificationException(object.getError());
 		}
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
@@ -230,7 +230,7 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 											super.getTaskName(), tarFileName, recordForUploadedTar.getId(),
 											recordForUploadedTar.getStatus());
 									List<StatusInfo> duplicateRows = dmeSyncWorkflowService.getService(access)
-											.findByOriginalFilePathAndSourceFileNameAndStatusNull(object.getOriginalFilePath(),
+											.findByOriginalFilePathAndSourceFileNameAndStatusFailed(object.getOriginalFilePath(),
 													tarFileName);
 									if (!duplicateRows.isEmpty()) {
 										List<Long> objectIds = duplicateRows.stream().map(StatusInfo::getId)
@@ -389,7 +389,7 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 								object.getTarContentsCount());
 						
 						// update the current status info row as completed so this workflow is completed and next task won't be processed.
-						object.setStatus(WorkflowConstants.IGNORED);
+						object.setStatus(WorkflowConstants.COMPLETED);
 						object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
 						object.setEndWorkflow(true);
 						object.setSourceFilePath(object.getOriginalFilePath());

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
@@ -318,8 +318,7 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 					if (totalFilesInTars != files.length) {
 						object.setError((" Files in original folder " + files.length
 								+ " doesn't match the files in multiple tars requests " + totalFilesInTars));
-						object.setStatus(WorkflowConstants.FAILED);
-						dmeSyncWorkflowService.getService(access).recordError(object);
+						dmeSyncWorkflowService.getService(access).recordError(object , true);
 						throw new DmeSyncVerificationException((" Files in original folder " + files.length
 								+ " doesn't match the files in multiple created tars " + totalFilesInTars));
 					} 
@@ -327,9 +326,8 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 						// verify if all the tar requests are inserted in status_info table.If not throw the exception
 						object.setError((" Expected tar creation Requests " + expectedTarRequests
 								+ " doesn't match the creation requests in DB " + totalTarsRequests));
-						object.setStatus(WorkflowConstants.FAILED);
-						dmeSyncWorkflowService.getService(access).recordError(object);
-						throw new DmeSyncVerificationException((" Expected tar creation Requests " + expectedTarRequests
+						dmeSyncWorkflowService.getService(access).recordError(object , true);
+						throw new DmeSyncWorkflowException((" Expected tar creation Requests " + expectedTarRequests
 								+ " doesn't match the creation requests in DB " + totalTarsRequests));
 						
 						
@@ -591,8 +589,7 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 		if (coveredFolders != expectedCovered) {
 			object.setError("Grouped site folder coverage mismatch: covered=" + coveredFolders + " expected="
 					+ expectedCovered);
-			object.setStatus(WorkflowConstants.FAILED);
-			dmeSyncWorkflowService.getService(access).recordError(object);
+			dmeSyncWorkflowService.getService(access).recordError(object , true);
 			throw new DmeSyncVerificationException(object.getError());
 		}
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarContentsFileTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarContentsFileTaskImpl.java
@@ -169,6 +169,7 @@ public class DmeSyncTarContentsFileTaskImpl extends AbstractDmeSyncTask implemen
 						checkForUploadedContentsFile.getStatus());
 			} else {
 				checkForUploadedContentsFile.setRunId(object.getRunId());
+				checkForUploadedContentsFile.setStatus(null);
 				checkForUploadedContentsFile.setError("");
 				checkForUploadedContentsFile.setRetryCount(0L);
 				checkForUploadedContentsFile.setEndWorkflow(false);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarTaskImpl.java
@@ -248,7 +248,8 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 		}
 		}else {
 			logger.info("No need to upload file : {}", object.getOriginalFilePath());
-			object.setStatus(WorkflowConstants.IGNORED);
+
+			object.setStatus(WorkflowConstants.FAILED);
 			object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
 			object.setEndWorkflow(true);
 			object.setError("No need to upload yet");

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncTarTaskImpl.java
@@ -248,7 +248,8 @@ public class DmeSyncTarTaskImpl extends AbstractDmeSyncTask implements DmeSyncTa
 		}
 		}else {
 			logger.info("No need to upload file : {}", object.getOriginalFilePath());
-			object.setRunId(object.getRunId() + WorkflowConstants.IGNORED_RUN_SUFFIX);
+			object.setStatus(WorkflowConstants.IGNORED);
+			object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
 			object.setEndWorkflow(true);
 			object.setError("No need to upload yet");
 			object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
@@ -38,6 +38,7 @@ public class DmeSyncWorkflowImpl implements DmeSyncWorkflow {
 
   private List<DmeSyncTask> tasks;
 
+  boolean setStatus = false;
   @Autowired private DmeSyncUploadTaskImpl syncUploadTask;
   @Autowired private DmeSyncPresignUploadTaskImpl presignUploadTask;
   @Autowired private DmeSyncFileSystemUploadTaskImpl fileSystemUploadTask;
@@ -111,6 +112,9 @@ public class DmeSyncWorkflowImpl implements DmeSyncWorkflow {
   
   @Value("${dmesync.selective.scan:false}")
   private boolean selectiveScan;
+  
+  @Value("${dmesync.activemq.maximum.retires}")
+  private int maximumRetries;
   
   @PostConstruct
   public boolean init() {
@@ -198,24 +202,34 @@ public class DmeSyncWorkflowImpl implements DmeSyncWorkflow {
       
       // In case of mapping or verification exception on async, retry will not help.
       statusInfo.setError(e.getMessage());
-      dmeSyncWorkflowService.getService(access).recordError(statusInfo);
+      dmeSyncWorkflowService.getService(access).recordError(statusInfo , setStatus);
       
     } catch (DmeSyncStorageException e) {
         
         // In case of space issue while tarring, retry will not help.
         statusInfo.setError(e.getMessage());
-        dmeSyncWorkflowService.getService(access).recordError(statusInfo);
+        dmeSyncWorkflowService.getService(access).recordError(statusInfo , setStatus);
         
       }catch (DmeSyncWorkflowException e) {
       
+      if(statusInfo.getRetryCount() == maximumRetries) {
+		 logger.error("[Workflow] Maximum retries exceeded for StatusInfo ID: " + statusInfo.getId(), e);
+		 setStatus = true;
+		  
+	  }
       statusInfo.setRetryCount(statusInfo.getRetryCount() + 1);
-      dmeSyncWorkflowService.getService(access).retryWorkflow(statusInfo, e);
+      dmeSyncWorkflowService.getService(access).retryWorkflow(statusInfo, setStatus, e);
       
       throw e;
       
     } catch (Exception e) {
       
-      dmeSyncWorkflowService.getService(access).retryWorkflow(statusInfo, e);
+       if(statusInfo.getRetryCount() == maximumRetries) {
+   		 logger.error("[Workflow] Maximum retries exceeded for StatusInfo ID: " + statusInfo.getId(), e);
+   		 setStatus = true;
+   		  
+   	   }
+      dmeSyncWorkflowService.getService(access).retryWorkflow(statusInfo, setStatus ,e );
     }
   }
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncWorkflowImpl.java
@@ -202,13 +202,13 @@ public class DmeSyncWorkflowImpl implements DmeSyncWorkflow {
       
       // In case of mapping or verification exception on async, retry will not help.
       statusInfo.setError(e.getMessage());
-      dmeSyncWorkflowService.getService(access).recordError(statusInfo , setStatus);
+      dmeSyncWorkflowService.getService(access).recordError(statusInfo , true);
       
     } catch (DmeSyncStorageException e) {
         
         // In case of space issue while tarring, retry will not help.
         statusInfo.setError(e.getMessage());
-        dmeSyncWorkflowService.getService(access).recordError(statusInfo , setStatus);
+        dmeSyncWorkflowService.getService(access).recordError(statusInfo , true);
         
       }catch (DmeSyncWorkflowException e) {
       

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,8 @@ spring.jpa.hibernate.ddl-auto = update
 #spring.activemq.user=smx
 #spring.activemq.password=smx
 # To use embedded ActiveMQ, activate below and comment out above
-spring.activemq.broker-url=vm://embedded?broker.persistent=false,useShutdownHook=false,useJmx=false,jms.prefetchPolicy.queuePrefetch=0
+dmesync.activemq.maximum.retires=6
+spring.activemq.broker-url=vm://embedded?broker.persistent=false,useShutdownHook=false,useJmx=false,jms.prefetchPolicy.queuePrefetch=0,jms.redeliveryPolicy.maximumRedeliveries=${dmesync.activemq.maximum.retires}
 spring.activemq.in-memory=true
 spring.activemq.pool.enabled=true
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,8 +15,7 @@ spring.jpa.hibernate.ddl-auto = update
 #spring.activemq.user=smx
 #spring.activemq.password=smx
 # To use embedded ActiveMQ, activate below and comment out above
-dmesync.activemq.maximum.retires=6
-spring.activemq.broker-url=vm://embedded?broker.persistent=false,useShutdownHook=false,useJmx=false,jms.prefetchPolicy.queuePrefetch=0,jms.redeliveryPolicy.maximumRedeliveries=${dmesync.activemq.maximum.retires}
+spring.activemq.broker-url=vm://embedded?broker.persistent=false,useShutdownHook=false,useJmx=false,jms.prefetchPolicy.queuePrefetch=0
 spring.activemq.in-memory=true
 spring.activemq.pool.enabled=true
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ spring.jpa.hibernate.ddl-auto = update
 spring.activemq.broker-url=vm://embedded?broker.persistent=false,useShutdownHook=false,useJmx=false,jms.prefetchPolicy.queuePrefetch=0
 spring.activemq.in-memory=true
 spring.activemq.pool.enabled=true
-
+dmesync.activemq.maximum.retires=6
 # Spring JMS Settings
 spring.jms.listener.concurrency=10
 spring.jms.listener.max-concurrency=10

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -6,4 +6,4 @@ EMPTY_COLLECTION_MSG=Metadata entry collection cannot be null.
 EMPTY_BULK_METADATA_MSG=Bulk metadata entry cannot be null.
 EMPTY_PATH_METADATA_MSG=Path metadata entries cannot be null.
 NULL_METADATA_ENTRY_MSG=Metadata entry cannot be null.
-MISMATCH_STATUS=Mismatch in archival status. File not uploaded.
+MISMATCH_STATUS_MSG=Mismatch in archival status. File not uploaded.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -6,3 +6,4 @@ EMPTY_COLLECTION_MSG=Metadata entry collection cannot be null.
 EMPTY_BULK_METADATA_MSG=Bulk metadata entry cannot be null.
 EMPTY_PATH_METADATA_MSG=Path metadata entries cannot be null.
 NULL_METADATA_ENTRY_MSG=Metadata entry cannot be null.
+MISMATCH_STATUS=Mismatch in archival status. File not uploaded.

--- a/src/test/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImplStatusTest.java
+++ b/src/test/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImplStatusTest.java
@@ -33,7 +33,7 @@ class DmeSyncWorkflowServiceImplStatusTest {
     statusInfo.setId(21L);
     statusInfo.setStatus(WorkflowConstants.IGNORED);
 
-    service.retryWorkflow(statusInfo, new RuntimeException("ignored"));
+    service.retryWorkflow(statusInfo, true, new RuntimeException("ignored"));
 
     assertEquals(WorkflowConstants.IGNORED, statusInfo.getStatus());
     verify(statusInfoDao).saveAndFlush(statusInfo);
@@ -51,7 +51,7 @@ class DmeSyncWorkflowServiceImplStatusTest {
     StatusInfo statusInfo = new StatusInfo();
     statusInfo.setStatus(WorkflowConstants.COMPLETED);
 
-    service.recordError(statusInfo);
+    service.recordError(statusInfo, true);
 
     assertEquals(WorkflowConstants.FAILED, statusInfo.getStatus());
     verify(statusInfoDao).saveAndFlush(statusInfo);

--- a/src/test/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImplStatusTest.java
+++ b/src/test/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImplStatusTest.java
@@ -1,0 +1,77 @@
+package gov.nih.nci.hpc.dmesync.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import gov.nih.nci.hpc.dmesync.dao.MetadataInfoDao;
+import gov.nih.nci.hpc.dmesync.dao.StatusInfoDao;
+import gov.nih.nci.hpc.dmesync.dao.TaskInfoDao;
+import gov.nih.nci.hpc.dmesync.domain.MetadataInfo;
+import gov.nih.nci.hpc.dmesync.domain.StatusInfo;
+import gov.nih.nci.hpc.dmesync.domain.TaskInfo;
+import gov.nih.nci.hpc.dmesync.util.WorkflowConstants;
+
+class DmeSyncWorkflowServiceImplStatusTest {
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void completeWorkflowMarksBlankStatusCompleted() {
+    DmeSyncWorkflowServiceImpl service = new DmeSyncWorkflowServiceImpl();
+    StatusInfoDao<StatusInfo> statusInfoDao = Mockito.mock(StatusInfoDao.class);
+    TaskInfoDao<TaskInfo> taskInfoDao = Mockito.mock(TaskInfoDao.class);
+
+    ReflectionTestUtils.setField(service, "statusInfoDao", statusInfoDao);
+    ReflectionTestUtils.setField(service, "taskInfoDao", taskInfoDao);
+
+    StatusInfo statusInfo = new StatusInfo();
+    statusInfo.setId(11L);
+
+    service.completeWorkflow(statusInfo);
+
+    assertEquals(WorkflowConstants.COMPLETED, statusInfo.getStatus());
+    verify(statusInfoDao).saveAndFlush(statusInfo);
+    verify(taskInfoDao).deleteByObjectId(11L);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void recordErrorPreservesIgnoredStatus() {
+    DmeSyncWorkflowServiceImpl service = new DmeSyncWorkflowServiceImpl();
+    StatusInfoDao<StatusInfo> statusInfoDao = Mockito.mock(StatusInfoDao.class);
+    MetadataInfoDao<MetadataInfo> metadataInfoDao = Mockito.mock(MetadataInfoDao.class);
+
+    ReflectionTestUtils.setField(service, "statusInfoDao", statusInfoDao);
+    ReflectionTestUtils.setField(service, "metadataInfoDao", metadataInfoDao);
+
+    StatusInfo statusInfo = new StatusInfo();
+    statusInfo.setId(21L);
+    statusInfo.setStatus(WorkflowConstants.IGNORED);
+
+    service.retryWorkflow(statusInfo, new RuntimeException("ignored"));
+
+    assertEquals(WorkflowConstants.IGNORED, statusInfo.getStatus());
+    verify(statusInfoDao).saveAndFlush(statusInfo);
+    verify(metadataInfoDao).deleteByObjectId(21L);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void recordErrorMarksNonIgnoredStatusFailed() {
+    DmeSyncWorkflowServiceImpl service = new DmeSyncWorkflowServiceImpl();
+    StatusInfoDao<StatusInfo> statusInfoDao = Mockito.mock(StatusInfoDao.class);
+
+    ReflectionTestUtils.setField(service, "statusInfoDao", statusInfoDao);
+
+    StatusInfo statusInfo = new StatusInfo();
+    statusInfo.setStatus(WorkflowConstants.COMPLETED);
+
+    service.recordError(statusInfo);
+
+    assertEquals(WorkflowConstants.FAILED, statusInfo.getStatus());
+    verify(statusInfoDao).saveAndFlush(statusInfo);
+  }
+}

--- a/src/test/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImplStatusTest.java
+++ b/src/test/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImplStatusTest.java
@@ -17,25 +17,7 @@ import gov.nih.nci.hpc.dmesync.util.WorkflowConstants;
 
 class DmeSyncWorkflowServiceImplStatusTest {
 
-  @SuppressWarnings("unchecked")
-  @Test
-  void completeWorkflowMarksBlankStatusCompleted() {
-    DmeSyncWorkflowServiceImpl service = new DmeSyncWorkflowServiceImpl();
-    StatusInfoDao<StatusInfo> statusInfoDao = Mockito.mock(StatusInfoDao.class);
-    TaskInfoDao<TaskInfo> taskInfoDao = Mockito.mock(TaskInfoDao.class);
-
-    ReflectionTestUtils.setField(service, "statusInfoDao", statusInfoDao);
-    ReflectionTestUtils.setField(service, "taskInfoDao", taskInfoDao);
-
-    StatusInfo statusInfo = new StatusInfo();
-    statusInfo.setId(11L);
-
-    service.completeWorkflow(statusInfo);
-
-    assertEquals(WorkflowConstants.COMPLETED, statusInfo.getStatus());
-    verify(statusInfoDao).saveAndFlush(statusInfo);
-    verify(taskInfoDao).deleteByObjectId(11L);
-  }
+ 
 
   @SuppressWarnings("unchecked")
   @Test

--- a/src/test/java/gov/nih/nci/hpc/dmesync/util/WorkflowConstantsTest.java
+++ b/src/test/java/gov/nih/nci/hpc/dmesync/util/WorkflowConstantsTest.java
@@ -10,20 +10,11 @@ class WorkflowConstantsTest {
 
   @Test
   void retryableStatusIncludesFailedAndLegacyNullOnly() {
-    assertTrue(WorkflowConstants.isRetryableStatus(null));
     assertTrue(WorkflowConstants.isRetryableStatus("FAILED"));
-    assertTrue(WorkflowConstants.isRetryableStatus("FAILED.legacy detail"));
     assertFalse(WorkflowConstants.isRetryableStatus("COMPLETED"));
     assertFalse(WorkflowConstants.isRetryableStatus("IGNORED"));
   }
 
-  @Test
-  void displayStatusNormalizesLegacyFailures() {
-    assertEquals("FAILED", WorkflowConstants.getDisplayStatus(null));
-    assertEquals("FAILED", WorkflowConstants.getDisplayStatus("FAILED.detail"));
-    assertEquals("COMPLETED", WorkflowConstants.getDisplayStatus("COMPLETED"));
-    assertEquals("IGNORED", WorkflowConstants.getDisplayStatus("IGNORED"));
-  }
 
   @Test
   void ignoredRunIdSuffixIsAddedOnlyOnce() {

--- a/src/test/java/gov/nih/nci/hpc/dmesync/util/WorkflowConstantsTest.java
+++ b/src/test/java/gov/nih/nci/hpc/dmesync/util/WorkflowConstantsTest.java
@@ -1,0 +1,33 @@
+package gov.nih.nci.hpc.dmesync.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class WorkflowConstantsTest {
+
+  @Test
+  void retryableStatusIncludesFailedAndLegacyNullOnly() {
+    assertTrue(WorkflowConstants.isRetryableStatus(null));
+    assertTrue(WorkflowConstants.isRetryableStatus("FAILED"));
+    assertTrue(WorkflowConstants.isRetryableStatus("FAILED.legacy detail"));
+    assertFalse(WorkflowConstants.isRetryableStatus("COMPLETED"));
+    assertFalse(WorkflowConstants.isRetryableStatus("IGNORED"));
+  }
+
+  @Test
+  void displayStatusNormalizesLegacyFailures() {
+    assertEquals("FAILED", WorkflowConstants.getDisplayStatus(null));
+    assertEquals("FAILED", WorkflowConstants.getDisplayStatus("FAILED.detail"));
+    assertEquals("COMPLETED", WorkflowConstants.getDisplayStatus("COMPLETED"));
+    assertEquals("IGNORED", WorkflowConstants.getDisplayStatus("IGNORED"));
+  }
+
+  @Test
+  void ignoredRunIdSuffixIsAddedOnlyOnce() {
+    assertEquals("Run_1_IGNORED", WorkflowConstants.toIgnoredRunId("Run_1"));
+    assertEquals("Run_1_IGNORED", WorkflowConstants.toIgnoredRunId("Run_1_IGNORED"));
+  }
+}

--- a/src/test/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/DmeSyncSchedulerPriorRunRetryTest.java
+++ b/src/test/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/DmeSyncSchedulerPriorRunRetryTest.java
@@ -79,7 +79,7 @@ class DmeSyncSchedulerPriorRunRetryTest {
     DmeSyncScheduler scheduler = newSchedulerWithContext(
         sender, factory, workflowSvc, "local", "DOC1", baseDir.toString(), "Run_20260325010101");
 
-    when(workflowSvc.findAllStatusInfoLikeOriginalFilePath(baseDir.toString() + "%"))
+    when(workflowSvc.findAllFailedStatusInfoLikeOriginalFilePath(baseDir.toString() + "%"))
         .thenReturn(List.of());
 
     ReflectionTestUtils.invokeMethod(scheduler, "includePriorRunFailuresInCurrentRunWorklist");
@@ -104,7 +104,7 @@ class DmeSyncSchedulerPriorRunRetryTest {
     baseRow.setRunId("Run_20260225010101");
     baseRow.setStartTimestamp(new Date(1));
 
-    when(workflowSvc.findAllStatusInfoLikeOriginalFilePath(baseDir.toString() + "%"))
+    when(workflowSvc.findAllFailedStatusInfoLikeOriginalFilePath(baseDir.toString() + "%"))
         .thenReturn(List.of(baseRow));
     when(workflowSvc.findStatusInfoByRunIdAndDoc("Run_20260225010101", "DOC1"))
         .thenReturn(List.of());
@@ -138,7 +138,7 @@ class DmeSyncSchedulerPriorRunRetryTest {
     completed.setOriginalFilePath(java.nio.file.Files.createDirectory(baseDir.resolve("done")).toString());
     completed.setStatus("COMPLETED");
 
-    when(workflowSvc.findAllStatusInfoLikeOriginalFilePath(baseDir.toString() + "%"))
+    when(workflowSvc.findAllFailedStatusInfoLikeOriginalFilePath(baseDir.toString() + "%"))
         .thenReturn(List.of(baseRow));
     when(workflowSvc.findStatusInfoByRunIdAndDoc("Run_20260225010101", "DOC1"))
         .thenReturn(List.of(completed));
@@ -178,7 +178,7 @@ class DmeSyncSchedulerPriorRunRetryTest {
     failedOutside.setOriginalFilePath(java.nio.file.Files.createDirectory(otherDir.resolve("retry")).toString());
     failedOutside.setStatus("FAILED");
 
-    when(workflowSvc.findAllStatusInfoLikeOriginalFilePath(baseDir.toString() + "%"))
+    when(workflowSvc.findAllFailedStatusInfoLikeOriginalFilePath(baseDir.toString() + "%"))
         .thenReturn(List.of(baseRow));
     when(workflowSvc.findStatusInfoByRunIdAndDoc("Run_20260225010101", "DOC1"))
         .thenReturn(List.of(failedOutside));
@@ -217,7 +217,7 @@ class DmeSyncSchedulerPriorRunRetryTest {
     failedMissing.setOriginalFilePath(missing.toString());
     failedMissing.setStatus("FAILED");
 
-    when(workflowSvc.findAllStatusInfoLikeOriginalFilePath(baseDir.toString() + "%"))
+    when(workflowSvc.findAllFailedStatusInfoLikeOriginalFilePath(baseDir.toString() + "%"))
         .thenReturn(List.of(baseRow));
     when(workflowSvc.findStatusInfoByRunIdAndDoc("Run_20260225010101", "DOC1"))
         .thenReturn(List.of(failedMissing));


### PR DESCRIPTION
Enhance the DME Archival Workflow to replace the current implicit status behavior with three explicit statuses: COMPLETED, FAILED, and IGNORED. Today, successful records are marked as COMPLETED, while failures are often represented by status = null with an error message stored in the error column. This change should make failure and skip conditions explicit, standardize status usage across the application, and ensure that error is used only for descriptive details.

As part of this update, workflow task processing must be revised so that successful terminal records are marked COMPLETED, terminal error records are marked FAILED, and intentionally skipped or duplicate records are marked IGNORED. Scheduler rerun logic must also be updated so that ignored records are treated as terminal and are not selected for rerun. This includes changes to normal rerun handling, multiple-tar processing, and prior-run retry behavior.

In addition, update DmeSyncPresignUploadTaskImpl so that when dmesync.upload.modified.files=true and DME returns an “already archived” response, if the current file’s checksum and filesize match the already archived file, the workflow should mark the record as IGNORED instead of failing or retrying. If the archived file differs, existing versioned upload behavior should continue.

Mail/report generation should be updated . Legacy records where status is null  may require a one-time data backfill to convert failed rows to explicit FAILED.