### PR TITLE
Enhance the rerun upload completion check for symlink uploads.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>gov.nih.nci.hpc</groupId>
 	<artifactId>dme-sync</artifactId>
-	<version>2.10.0</version>
+	<version>2.10.0.1</version>
 	<name>dme-sync</name>
 	<packaging>jar</packaging>
 	<description>DME Auto-archival Workflow Application</description>

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -18,7 +18,7 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   
   /**
    * findFirstBySourceFilePathAndStatus
-   * @param sourceFilePath the original file path
+   * @param sourceFilePath the source file path
    * @param status the status
    * @return the StatusInfo object
    */

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -17,6 +17,14 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   StatusInfo findFirstByOriginalFilePathAndStatusOrderByStartTimestampDesc(String originalFilePath, String status);
   
   /**
+   * findFirstBySourceFilePathAndStatus
+   * @param sourceFilePath the original file path
+   * @param status the status
+   * @return the StatusInfo object
+   */
+  StatusInfo findFirstBySourceFilePathAndStatusOrderByStartTimestampDesc(String sourceFilePath, String status);
+  
+  /**
    * findFirstStatusInfoByFullDestinationPathAndStatus
    * @param FullDestinationPath the full destination path
    * @param status the status

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -612,7 +612,7 @@ public class DmeSyncScheduler {
     for (HpcPathAttributes file : files) {
 
       StatusInfo statusInfo = null;
-
+      Path fileFullPath= file.getAbsolutePath()!=null ? Paths.get(file.getAbsolutePath()):null;
       //If we need to verify previous upload, check
       if ("local".equals(verifyPrevUpload)) {
         // Checks the local db to see if it has been completed
@@ -726,6 +726,17 @@ public class DmeSyncScheduler {
 			statusInfo =
 		              dmeSyncWorkflowService.getService(access).findFirstStatusInfoByOriginalFilePathAndSourceFilePathAndStatus(
 		                  file.getAbsolutePath(), file.getPath(), "COMPLETED");
+		}
+		else if (fileFullPath!=null && Files.isSymbolicLink(fileFullPath)) {
+			Path sourceFilePath = Files.readSymbolicLink(fileFullPath);
+			if (!sourceFilePath.isAbsolute()) {
+				sourceFilePath = fileFullPath.getParent().resolve(sourceFilePath).normalize();
+			}
+			sourceFilePath = sourceFilePath.toAbsolutePath();
+			logger.debug("[Scheduler] Checking for symbolic link Completed status: Original filepath : {} , SourceFilePath: {}",
+					fileFullPath, sourceFilePath);
+			statusInfo = dmeSyncWorkflowService.getService(access)
+					.findFirstStatusInfoBySourceFilePathAndStatus(sourceFilePath.toString(), "COMPLETED");
 		}
 		else {
           statusInfo =

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -612,7 +612,7 @@ public class DmeSyncScheduler {
     for (HpcPathAttributes file : files) {
 
       StatusInfo statusInfo = null;
-      Path fileFullPath= file.getAbsolutePath()!=null ? Paths.get(file.getAbsolutePath()):null;
+		Path fileFullPath = file.getAbsolutePath() != null ? Paths.get(file.getAbsolutePath()) : null;
       //If we need to verify previous upload, check
       if ("local".equals(verifyPrevUpload)) {
         // Checks the local db to see if it has been completed

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -326,6 +326,16 @@ public interface DmeSyncWorkflowService {
    * @param List of object Ids.
    */
    void deleteStatusInfoByIds(List<Long> ids);
+   
+   
+   /**
+    * findFirstStatusInfoBySourceFilePathAndStatus
+    *
+    * @param sourceFilePath the source file path
+    * @param status the status
+    * @return the StatusInfo object
+    */
+   StatusInfo findFirstStatusInfoBySourceFilePathAndStatus(String originalFilePath, String status);
 
    StatusInfo findFirstStatusInfoByOriginalFilePathAndSourceFilePathNotEndsWith(String originalFilePath,
 		String sourceFilePath);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -335,7 +335,7 @@ public interface DmeSyncWorkflowService {
     * @param status the status
     * @return the StatusInfo object
     */
-   StatusInfo findFirstStatusInfoBySourceFilePathAndStatus(String originalFilePath, String status);
+   StatusInfo findFirstStatusInfoBySourceFilePathAndStatus(String sourceFilePath, String status);
 
    StatusInfo findFirstStatusInfoByOriginalFilePathAndSourceFilePathNotEndsWith(String originalFilePath,
 		String sourceFilePath);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -58,6 +58,12 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   }
   
   @Override
+  public StatusInfo findFirstStatusInfoBySourceFilePathAndStatus(
+      String sourceFilePath, String status) {
+    return statusInfoDao.findFirstBySourceFilePathAndStatusOrderByStartTimestampDesc(sourceFilePath, status);
+  }
+  
+  @Override
   public StatusInfo findFirstStatusInfoByFullDestinationPathAndStatus(
       String fullDestinationPath, String status) {
     return statusInfoDao.findFirstStatusInfoByFullDestinationPathAndStatus(fullDestinationPath, status);


### PR DESCRIPTION
Background:

After the data move for /data/DmeWorkflow, the SB FASTQ upload process was affected. We create symlinks for the FASTQ files under /data/DmeWorkflow/work/sb/fastq_files right. After the migration, the resolved absolute path for /data/DmeWorkflow changed from /gpfs/gsfs12/users to /vf/users. Because the scan checks upload status by querying the database using that resolved path, the files are being treated as new and picked up again for upload.

Problem

Currently, rerun checks may incorrectly evaluate completion status using the symlink itself, which can cause completed uploads to be rerun unnecessarily when the symlink path as changed . The updated logic should resolve symlinks to their target source files and use that target file which is sourcefilepath in the statusInfo table when checking whether the upload has already completed.

Expected behavior

When a rerun is triggered for a symlink upload, the system should:

Detect that the upload item is a symlink.
Resolve the symlink to its target/source file.
Check upload completion status  in status_info table using the resolved target file sourceFilePath column. 
Skip rerun if the target file upload is already complete.
Proceed with rerun only when the target file upload is incomplete or missing.
