### PR TITLE
DMESUPPORT-212 Enhance automated archival workflow error handling for already archived files without completed DB records

### DIFF
--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -244,9 +244,12 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 
 				}
 			} else {
-				// This scenario should happen when DME archive indicates the file is already archived, but no matching Completed database record was found for the file. 
+				/* This scenario should happen when DME archive indicates the file is already archived, but no matching Completed database record was found for the file. 
+				 * Manual verification of file is needed when this error happens.
+				 */
 				String msg = messageService.get("MISMATCH_STATUS_MSG");
-				logger.error("[{}] DME archive indicates the upload is already archived, but no matching Completed database record was found {}", super.getTaskName(), msg);
+				logger.error("[{}] DME archive indicates the upload is already archived, but no matching Completed database record was found ; "
+						+ " Manual verification of file is needed when this error happens {}", super.getTaskName(), msg);
 			    throw new DmeSyncVerificationException(msg);
 			}
 		}

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -244,8 +244,9 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 
 				}
 			} else {
+				// This scenario should happen when DME archive indicates the file is already archived, but no matching Completed database record was found for the file. 
 				String msg = messageService.get("MISMATCH_STATUS_MSG");
-				logger.error("[{}] {}", super.getTaskName(), msg);
+				logger.error("[{}] DME archive indicates the upload is already archived, but no matching Completed database record was found {}", super.getTaskName(), msg);
 			    throw new DmeSyncVerificationException(msg);
 			}
 		}

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -51,6 +51,7 @@ import gov.nih.nci.hpc.dmesync.exception.DmeSyncMappingException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncVerificationException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncWorkflowException;
 import gov.nih.nci.hpc.dmesync.workflow.DmeSyncTask;
+import gov.nih.nci.hpc.dmesync.workflow.MessageService;
 import gov.nih.nci.hpc.domain.datatransfer.HpcMultipartUpload;
 import gov.nih.nci.hpc.domain.datatransfer.HpcUploadPartETag;
 import gov.nih.nci.hpc.domain.datatransfer.HpcUploadPartURL;
@@ -71,6 +72,7 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
   @Autowired private RestTemplateFactory restTemplateFactory;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private DmeSyncDeleteDataObject dmeSyncDeleteDataObject;
+  @Autowired private MessageService messageService;
 
   @Value("${hpc.server.url}")
   private String serverUrl;
@@ -241,6 +243,10 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 					return object;
 
 				}
+			} else {
+				String msg = messageService.get("MISMATCH_STATUS");
+				logger.error("[{}] {}", super.getTaskName(), msg);
+			    throw new DmeSyncVerificationException(msg);
 			}
 		}
 	    logger.error("[{}] {}", super.getTaskName(), errorResponse.getStackTrace());

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncPresignUploadTaskImpl.java
@@ -244,7 +244,7 @@ public class DmeSyncPresignUploadTaskImpl extends AbstractDmeSyncTask implements
 
 				}
 			} else {
-				String msg = messageService.get("MISMATCH_STATUS");
+				String msg = messageService.get("MISMATCH_STATUS_MSG");
 				logger.error("[{}] {}", super.getTaskName(), msg);
 			    throw new DmeSyncVerificationException(msg);
 			}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -6,4 +6,4 @@ EMPTY_COLLECTION_MSG=Metadata entry collection cannot be null.
 EMPTY_BULK_METADATA_MSG=Bulk metadata entry cannot be null.
 EMPTY_PATH_METADATA_MSG=Path metadata entries cannot be null.
 NULL_METADATA_ENTRY_MSG=Metadata entry cannot be null.
-MISMATCH_STATUS=Mismatch in archival status. File not uploaded.
+MISMATCH_STATUS_MSG=Mismatch in archival status. File not uploaded.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -6,3 +6,4 @@ EMPTY_COLLECTION_MSG=Metadata entry collection cannot be null.
 EMPTY_BULK_METADATA_MSG=Bulk metadata entry cannot be null.
 EMPTY_PATH_METADATA_MSG=Path metadata entries cannot be null.
 NULL_METADATA_ENTRY_MSG=Metadata entry cannot be null.
+MISMATCH_STATUS=Mismatch in archival status. File not uploaded.


### PR DESCRIPTION
Enhance the automated archival workflow to improve error handling when an “already archived” error occurs, but no corresponding record with completed status is found in the database.

This issue occurs when the feature that allows users to upload duplicate files with an extension when the checksum does not match is enabled.

Currently, the workflow report shows the same error for both scenarios:

A duplicate file already exists in the DME path and was uploaded from another source.
A file was not uploaded correctly during a previous failed run.
Because both cases are reported the same way, the failed upload scenario may be mistakenly represented as an already archived file. This can cause confusion and may lead to downstream issues.

Expected Update:
Update the workflow/reporting logic so these scenarios are clearly distinguished in the error message.
Mismatch in archival status. File not uploaded.
 