### PR TITLE
DMESUPPORT-218 Minor fix when the folders no files/found in the sour…

### DIFF
--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -322,6 +322,19 @@ public class DmeSyncScheduler {
       List<HpcPathAttributes> files = new ArrayList<>();
       if (paths != null && paths.isEmpty()) {
         logger.info("[Scheduler] No files/folders found for runID: {}", runId);
+
+        String emailBody= "There were no files/folders found for processing"+(!StringUtils.isEmpty(syncBaseDirFolders)?" in "+syncBaseDirFolders+" folders":"")+ ".";
+        dmeSyncMailServiceFactory.getService(doc).sendMail("HPCDME Auto Archival Result for " + doc + " - Base Path: " + syncBaseDir,
+  			  emailBody);
+        try {
+            dmeSyncWorkflowRunLogService.updateWorkflowRunEnd(runId, doc, WorkflowConstants.RunStatus.SKIPPED.toString(),null);
+          } catch (IllegalArgumentException e) {
+            logger.warn("[Scheduler] Workflow run not found when updating run end to SKIPPED for runId: {}, doc: {}", runId, doc, e);
+          }
+		if (shutDownFlag) {
+			logger.info("[Scheduler] No files/folders found. Shutting down the application.");
+			DmeSyncApplication.shutdown();
+		}
         MDC.clear();
         return;
       } else {


### PR DESCRIPTION
This issue was found in NCEF. Last week the run was started . However, there are no folders in the source path and email was not send to user.

When the source directory is empty or the scan does not find any files, the workflow currently does not send the “No files found” email.

The fix is to send the email, update the status in the workflow_run_info table, and shut down the application if the shutdown flag is enabled.