### PR TITLE
DMESUPPORT-176 Regarding the files picked up in the each run for lcbg

### DIFF
--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/DmeMetadataBuilder.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/DmeMetadataBuilder.java
@@ -1,6 +1,6 @@
 package gov.nih.nci.hpc.dmesync.util;
 
-import java.io.IOException;
+
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -27,7 +27,7 @@ public class DmeMetadataBuilder {
 
 	@Cacheable(value = "metadata", key = "'dmeMetadata'", sync = true)
 	public Map<String, Map<String, String>> getMetadataMap(String metadataFile, String key)
-			throws DmeSyncMappingException, DmeSyncWorkflowException, IOException {
+			throws DmeSyncMappingException, DmeSyncWorkflowException {
 
 		logger.info("Parsing the Metadata Spreadsheet and creating Metadata Map");
 		return ExcelUtil.parseBulkMetadataEntries(metadataFile, key);
@@ -35,7 +35,7 @@ public class DmeMetadataBuilder {
 
 	@CachePut(value = "metadata", key = "'dmeMetadata'")
 	public Map<String, Map<String, String>> updateMetadataMap(String metadataFile, String key)
-			throws DmeSyncMappingException, DmeSyncWorkflowException, IOException {
+			throws DmeSyncMappingException, DmeSyncWorkflowException {
 
 		logger.info("Updating the Metadata Spreadsheet and creating Metadata Map");
 		return ExcelUtil.parseBulkMetadataEntries(metadataFile, key);
@@ -43,21 +43,21 @@ public class DmeMetadataBuilder {
 
 	@Cacheable(value = "metadata", key = "'piMetadata'", sync = true)
 	public Map<String, Map<String, String>> getPIMetadataMap(String metadataFile, String key)
-			throws DmeSyncMappingException, DmeSyncWorkflowException, IOException {
+			throws DmeSyncMappingException, DmeSyncWorkflowException {
 		logger.info("Parsing the PI Metadata Spreadsheet and creating Map");
 		return ExcelUtil.parseBulkMetadataEntries(metadataFile, key);
 	}
 
 	@CachePut(value = "metadata", key = "'piMetadata'")
 	public Map<String, Map<String, String>> updatePIMetadataMap(String metadataFile, String key)
-			throws DmeSyncMappingException, DmeSyncWorkflowException, IOException {
+			throws DmeSyncMappingException, DmeSyncWorkflowException {
 		logger.info("Updating the PI Metadata Spreadsheet and creating Map");
 		return ExcelUtil.parseBulkMetadataEntries(metadataFile, key);
 	}
 	
 	@Cacheable(value = "metadata", key = "'dmeMetadataTwoKeys'", sync = true)
 	public Map<String, Map<String, String>> getMetadataMapWithTwoKeys(String metadataFile, String key1, String key2)
-			throws DmeSyncMappingException, DmeSyncWorkflowException, IOException {
+			throws DmeSyncMappingException, DmeSyncWorkflowException {
 
 		logger.info("Parsing the Metadata Spreadsheet and creating Metadata Map");
 		return ExcelUtil.parseBulkMetadataEntries(metadataFile, key1, key2);
@@ -65,7 +65,7 @@ public class DmeMetadataBuilder {
 
 	@CachePut(value = "metadata", key = "'dmeMetadataTwoKeys'")
 	public Map<String, Map<String, String>> updateMetadataMapWithTwoKeys(String metadataFile, String key1, String key2)
-			throws DmeSyncMappingException, DmeSyncWorkflowException, IOException {
+			throws DmeSyncMappingException, DmeSyncWorkflowException {
 
 		logger.info("Updating the Metadata Spreadsheet and creating Metadata Map");
 		return ExcelUtil.parseBulkMetadataEntries(metadataFile, key1, key2);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
@@ -372,6 +372,10 @@ public abstract class AbstractPathMetadataProcessor implements DmeSyncPathMetada
    }
    
    public boolean isArchiveReady(String key) {
+	   
+	   if (metadataMap == null || !metadataMap.containsKey(key)) {
+ 		   return false;
+ 	   }
 	   String archiveStatus = getAttrValueWithExactKeyFromMetadataMap(key, "Archive");
 		
 	   if (StringUtils.isBlank(archiveStatus)) {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
@@ -373,7 +373,11 @@ public abstract class AbstractPathMetadataProcessor implements DmeSyncPathMetada
    
    public boolean isArchiveReady(String key) {
 	   String archiveStatus = getAttrValueWithExactKeyFromMetadataMap(key, "Archive");
-		return  archiveStatus != null && archiveStatus.trim().matches("(?i)^(archive|archived|yes|y|true|1)\\s*\\.?$");
+		
+	   if (StringUtils.isBlank(archiveStatus)) {
+ 		   return true;
+ 	   }
+ 	   return archiveStatus.trim().matches("(?i)^(archive|archived|yes|y|true|1)\\s*\\.?$");
    }
   
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/AbstractPathMetadataProcessor.java
@@ -370,6 +370,11 @@ public abstract class AbstractPathMetadataProcessor implements DmeSyncPathMetada
 	    }
 	    return (metadataMapWithTwoKeys.get(key1 + "_" + key2) == null? null : metadataMapWithTwoKeys.get(key1 + "_" + key2).get(attrKey));
    }
+   
+   public boolean isArchiveReady(String key) {
+	   String archiveStatus = getAttrValueWithExactKeyFromMetadataMap(key, "Archive");
+		return  archiveStatus != null && archiveStatus.trim().matches("(?i)^(archive|archived|yes|y|true|1)\\s*\\.?$");
+   }
   
 
 }

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/LCBGSDSPathMetadataProcessorImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/LCBGSDSPathMetadataProcessorImpl.java
@@ -1,14 +1,17 @@
 package gov.nih.nci.hpc.dmesync.workflow.custom.impl;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import gov.nih.nci.hpc.dmesync.domain.StatusInfo;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncMappingException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncWorkflowException;
+import gov.nih.nci.hpc.dmesync.util.DmeMetadataBuilder;
 import gov.nih.nci.hpc.dmesync.workflow.DmeSyncPathMetadataProcessor;
 import gov.nih.nci.hpc.domain.metadata.HpcBulkMetadataEntries;
 import gov.nih.nci.hpc.domain.metadata.HpcBulkMetadataEntry;
@@ -28,13 +31,17 @@ public class LCBGSDSPathMetadataProcessorImpl extends AbstractPathMetadataProces
 	@Value("${dmesync.additional.metadata.excel:}")
 	private String metadataFile;
 	
+	@Autowired
+	private DmeMetadataBuilder dmeMetadataBuilder;
+	
 	@Override
-	public String getArchivePath(StatusInfo object) throws DmeSyncMappingException {
+	public String getArchivePath(StatusInfo object) throws DmeSyncMappingException, DmeSyncWorkflowException, IOException {
 
 		logger.info("[PathMetadataTask] LCBG SDS getArchivePath called");
 
+		
 		// load the user metadata from the externally placed excel
-		threadLocalMap.set(loadMetadataFile(metadataFile, "path"));
+	    metadataMap = dmeMetadataBuilder.getMetadataMap(metadataFile, "Folder");
 				
 		// extract the user name from the Path
 		// Example path - /Cappell-Section/Adrijana/AC053_AXXAi_Gem_CDK2_sibTRCP/Raw/*
@@ -67,7 +74,7 @@ public class LCBGSDSPathMetadataProcessorImpl extends AbstractPathMetadataProces
 
 		String userId = getUserId(object);
 		String path = getPath(object);
-
+		String fileName = Paths.get(object.getSourceFilePath()).toFile().getName();
 		// Add to HpcBulkMetadataEntries for path attributes
 		HpcBulkMetadataEntries hpcBulkMetadataEntries = new HpcBulkMetadataEntries();
 
@@ -100,17 +107,17 @@ public class LCBGSDSPathMetadataProcessorImpl extends AbstractPathMetadataProces
 		String projectPath = researcherPath + "/Project_" + projectCollectionName;
 		pathEntriesProject.setPath(projectPath.replace(" ", "_"));
 		pathEntriesProject.getPathMetadataEntries().add(createPathEntry("project_id", projectCollectionName));
-		pathEntriesProject.getPathMetadataEntries().add(createPathEntry("project_title", getAttrValueWithKey(path, "project_title")));
-		pathEntriesProject.getPathMetadataEntries().add(createPathEntry("project_description", getAttrValueWithKey(path, "project_description")));
-		pathEntriesProject.getPathMetadataEntries().add(createPathEntry("project_start_date", getAttrValueWithKey(path, "project_start_date"), "yyyy_MM_dd"));
+		pathEntriesProject.getPathMetadataEntries().add(createPathEntry("project_title", getAttrValueWithExactKeyFromMetadataMap(path, "project_title")));
+		pathEntriesProject.getPathMetadataEntries().add(createPathEntry("project_description", getAttrValueWithExactKeyFromMetadataMap(path, "project_description")));
+		pathEntriesProject.getPathMetadataEntries().add(createPathEntry("project_start_date", getAttrValueWithExactKeyFromMetadataMap(path, "project_start_date"), "yyyy_MM_dd"));
 		pathEntriesProject.getPathMetadataEntries().add(createPathEntry("data_generating_facility", "LCBG SDS"));
 		pathEntriesProject.getPathMetadataEntries().add(createPathEntry("access", "Closed Access"));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "key_collaborator")))
-			pathEntriesProject.getPathMetadataEntries().add(createPathEntry("key_collaborator", getAttrValueWithKey(path, "key_collaborator")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "key_collaborator_affiliation")))
-			pathEntriesProject.getPathMetadataEntries().add(createPathEntry("key_collaborator_affiliation", getAttrValueWithKey(path, "key_collaborator_affiliation")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "key_collaborator_email")))
-			pathEntriesProject.getPathMetadataEntries().add(createPathEntry("key_collaborator_email", getAttrValueWithKey(path, "key_collaborator_email")));		
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "key_collaborator")))
+			pathEntriesProject.getPathMetadataEntries().add(createPathEntry("key_collaborator", getAttrValueWithExactKeyFromMetadataMap(path, "key_collaborator")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "key_collaborator_affiliation")))
+			pathEntriesProject.getPathMetadataEntries().add(createPathEntry("key_collaborator_affiliation", getAttrValueWithExactKeyFromMetadataMap(path, "key_collaborator_affiliation")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "key_collaborator_email")))
+			pathEntriesProject.getPathMetadataEntries().add(createPathEntry("key_collaborator_email", getAttrValueWithExactKeyFromMetadataMap(path, "key_collaborator_email")));		
 		pathEntriesProject.getPathMetadataEntries().add(createPathEntry(COLLECTION_TYPE_ATTRIBUTE, "Project"));
 		hpcBulkMetadataEntries.getPathsMetadataEntries().add(populateStoredMetadataEntries(pathEntriesProject,
 				"Project", researcherCollectionName, "lcbg-sds"));
@@ -121,40 +128,40 @@ public class LCBGSDSPathMetadataProcessorImpl extends AbstractPathMetadataProces
 		String expPath = projectPath + "/Experiment_" + expCollectionName;
 		pathEntriesExp.setPath(expPath.replace(" ", "_"));
 		pathEntriesExp.getPathMetadataEntries().add(createPathEntry("experiment_name", expCollectionName));
-		pathEntriesExp.getPathMetadataEntries().add(createPathEntry("experiment_id", getAttrValueWithKey(path, "experiment_id")));
-		pathEntriesExp.getPathMetadataEntries().add(createPathEntry("experiment_date", getAttrValueWithKey(path, "experiment_date")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "experiment_type")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("experiment_type", getAttrValueWithKey(path, "experiment_type")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "number_of_samples")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("number_of_samples", getAttrValueWithKey(path, "number_of_samples")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "cell_line")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("cell_line", getAttrValueWithKey(path, "cell_line")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "instrument_id")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("instrument_id", getAttrValueWithKey(path, "instrument_id")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "instrument_name")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("instrument_name", getAttrValueWithKey(path, "instrument_name")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "treatments")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("treatments", getAttrValueWithKey(path, "treatments")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "num_frames")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("num_frames", getAttrValueWithKey(path, "num_frames")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "frame_drug_added")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("frame_drug_added", getAttrValueWithKey(path, "frame_drug_added")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "frame_wash")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("frame_wash", getAttrValueWithKey(path, "frame_wash")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "binning")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("binning", getAttrValueWithKey(path, "binning")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "frame_rate")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("frame_rate", getAttrValueWithKey(path, "frame_rate")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "flourescent_protein_1")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("fluorescent_protein_1", getAttrValueWithKey(path, "flourescent_protein_1")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "flourescent_protein_2")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("fluorescent_protein_2", getAttrValueWithKey(path, "flourescent_protein_2")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "flourescent_protein_3")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("fluorescent_protein_3", getAttrValueWithKey(path, "flourescent_protein_3")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "flourescent_protein_4")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("fluorescent_protein_4", getAttrValueWithKey(path, "flourescent_protein_4")));
-		if (StringUtils.isNotBlank(getAttrValueWithKey(path, "flourescent_protein_5")))
-			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("fluorescent_protein_5", getAttrValueWithKey(path, "flourescent_protein_5")));
+		pathEntriesExp.getPathMetadataEntries().add(createPathEntry("experiment_id", getAttrValueWithExactKeyFromMetadataMap(path, "experiment_id")));
+		pathEntriesExp.getPathMetadataEntries().add(createPathEntry("experiment_date", getAttrValueWithExactKeyFromMetadataMap(path, "experiment_date")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "experiment_type")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("experiment_type", getAttrValueWithExactKeyFromMetadataMap(path, "experiment_type")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "number_of_samples")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("number_of_samples", getAttrValueWithExactKeyFromMetadataMap(path, "number_of_samples")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "cell_line")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("cell_line", getAttrValueWithExactKeyFromMetadataMap(path, "cell_line")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "instrument_id")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("instrument_id", getAttrValueWithExactKeyFromMetadataMap(path, "instrument_id")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "instrument_name")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("instrument_name", getAttrValueWithExactKeyFromMetadataMap(path, "instrument_name")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "treatments")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("treatments", getAttrValueWithExactKeyFromMetadataMap(path, "treatments")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "num_frames")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("num_frames", getAttrValueWithExactKeyFromMetadataMap(path, "num_frames")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "frame_drug_added")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("frame_drug_added", getAttrValueWithExactKeyFromMetadataMap(path, "frame_drug_added")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "frame_wash")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("frame_wash", getAttrValueWithExactKeyFromMetadataMap(path, "frame_wash")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "binning")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("binning", getAttrValueWithExactKeyFromMetadataMap(path, "binning")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "frame_rate")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("frame_rate", getAttrValueWithExactKeyFromMetadataMap(path, "frame_rate")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "flourescent_protein_1")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("fluorescent_protein_1", getAttrValueWithExactKeyFromMetadataMap(path, "flourescent_protein_1")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "flourescent_protein_2")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("fluorescent_protein_2", getAttrValueWithExactKeyFromMetadataMap(path, "flourescent_protein_2")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "flourescent_protein_3")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("fluorescent_protein_3", getAttrValueWithExactKeyFromMetadataMap(path, "flourescent_protein_3")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "flourescent_protein_4")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("fluorescent_protein_4", getAttrValueWithExactKeyFromMetadataMap(path, "flourescent_protein_4")));
+		if (StringUtils.isNotBlank(getAttrValueWithExactKeyFromMetadataMap(path, "flourescent_protein_5")))
+			pathEntriesExp.getPathMetadataEntries().add(createPathEntry("fluorescent_protein_5", getAttrValueWithExactKeyFromMetadataMap(path, "flourescent_protein_5")));
 		pathEntriesExp.getPathMetadataEntries().add(createPathEntry(COLLECTION_TYPE_ATTRIBUTE, "Experiment"));
 		hpcBulkMetadataEntries.getPathsMetadataEntries().add(pathEntriesExp);
 		
@@ -166,7 +173,7 @@ public class LCBGSDSPathMetadataProcessorImpl extends AbstractPathMetadataProces
 
 		// Add object metadata
 		dataObjectRegistrationRequestDTO.getMetadataEntries()
-				.add(createPathEntry("object_name", object.getOrginalFileName()));
+				.add(createPathEntry("object_name", fileName));
 		dataObjectRegistrationRequestDTO.getMetadataEntries()
 				.add(createPathEntry("source_path", object.getOriginalFilePath()));
 
@@ -174,6 +181,14 @@ public class LCBGSDSPathMetadataProcessorImpl extends AbstractPathMetadataProces
 		return dataObjectRegistrationRequestDTO;
 	}
 
+	@Override
+    public boolean isMetadataAvailable(StatusInfo object) throws DmeSyncMappingException {
+		
+		   // Check if this project is in the metadata spreadsheet
+			String experimentName = getExpCollectionName(object);
+			return experimentName != null;
+	}
+	
 	private String getCollectionNameFromParent(StatusInfo object, String parentName) {
 		Path fullFilePath = Paths.get(object.getOriginalFilePath());
 		logger.info("Full File Path = {}", fullFilePath);
@@ -204,10 +219,10 @@ public class LCBGSDSPathMetadataProcessorImpl extends AbstractPathMetadataProces
 	}
 
 	private String getProjectCollectionName(StatusInfo object) throws DmeSyncMappingException {
-		return getAttrValueWithKey(getPath(object), "project_id");
+		return getAttrValueWithExactKeyFromMetadataMap(getPath(object), "project_id");
 	}
 
 	private String getExpCollectionName(StatusInfo object) {
-		return getAttrValueWithKey(getPath(object), "experiment_name");
+		return getAttrValueWithExactKeyFromMetadataMap(getPath(object), "experiment_name");
 	}
 }

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/LCBGSDSPathMetadataProcessorImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/custom/impl/LCBGSDSPathMetadataProcessorImpl.java
@@ -40,8 +40,7 @@ public class LCBGSDSPathMetadataProcessorImpl extends AbstractPathMetadataProces
 		logger.info("[PathMetadataTask] LCBG SDS getArchivePath called");
 
 		
-		// load the user metadata from the externally placed excel
-	    metadataMap = dmeMetadataBuilder.getMetadataMap(metadataFile, "Folder");
+		
 				
 		// extract the user name from the Path
 		// Example path - /Cappell-Section/Adrijana/AC053_AXXAi_Gem_CDK2_sibTRCP/Raw/*
@@ -182,11 +181,14 @@ public class LCBGSDSPathMetadataProcessorImpl extends AbstractPathMetadataProces
 	}
 
 	@Override
-    public boolean isMetadataAvailable(StatusInfo object) throws DmeSyncMappingException {
+    public boolean isMetadataAvailable(StatusInfo object) throws DmeSyncMappingException, DmeSyncWorkflowException {
 		
+		 // load the user metadata from the externally placed excel
+	        metadataMap = dmeMetadataBuilder.getMetadataMap(metadataFile, "path");
 		   // Check if this project is in the metadata spreadsheet
 			String experimentName = getExpCollectionName(object);
-			return experimentName != null;
+			String path = getPath(object);
+			return experimentName != null && isArchiveReady(path);
 	}
 	
 	private String getCollectionNameFromParent(StatusInfo object, String parentName) {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
@@ -24,14 +24,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import gov.nih.nci.hpc.dmesync.DmeSyncPathMetadataProcessorFactory;
 import gov.nih.nci.hpc.dmesync.domain.StatusInfo;
 import gov.nih.nci.hpc.dmesync.dto.DmeSyncMessageDto;
+import gov.nih.nci.hpc.dmesync.exception.DmeSyncMappingException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncStorageException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncVerificationException;
 import gov.nih.nci.hpc.dmesync.exception.DmeSyncWorkflowException;
 import gov.nih.nci.hpc.dmesync.jms.DmeSyncProducer;
 import gov.nih.nci.hpc.dmesync.util.TarUtil;
 import gov.nih.nci.hpc.dmesync.util.WorkflowConstants;
+import gov.nih.nci.hpc.dmesync.workflow.DmeSyncPathMetadataProcessor;
 import gov.nih.nci.hpc.dmesync.workflow.DmeSyncTask;
 
 /**
@@ -93,6 +96,9 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 	@Value("${dmesync.multiple.tars.batch.folder.delimiter.level:0}")
 	private int batchFolderDelimiterLevel;
 	
+	@Autowired 
+	private DmeSyncPathMetadataProcessorFactory metadataProcessorFactory;
+	
 	@PostConstruct
 	public boolean init() {
 		super.setTaskName("ProcessMultipleTarsTask");
@@ -102,7 +108,7 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 
 	@Override
 	public StatusInfo process(StatusInfo object)
-			throws DmeSyncVerificationException, DmeSyncWorkflowException, DmeSyncStorageException {
+			throws DmeSyncVerificationException, DmeSyncWorkflowException, DmeSyncStorageException, DmeSyncMappingException {
 
 		/**
 		 * This task is only applicable for some folders in Dataset so below
@@ -112,8 +118,11 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 		String sourceDirLeafNode = object.getSourceFilePath() != null
 				? ((Paths.get(object.getSourceFilePath())).getFileName()).toString()
 				: null;
-		if (TarUtil.matchesAnyMultipleTarFolder( multipleTarsFolders , sourceDirLeafNode )) {
-
+		
+		DmeSyncPathMetadataProcessor metadataTask = metadataProcessorFactory.getService(doc);
+		if (metadataTask.isMetadataAvailable(object)) {
+		  if (TarUtil.matchesAnyMultipleTarFolder( multipleTarsFolders , sourceDirLeafNode )) {
+			  
 			try {
 
 				Path baseDirPath = Paths.get(syncBaseDir).toRealPath();
@@ -164,8 +173,8 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 					
 					Arrays.sort(files, Comparator.comparing(File::lastModified));
 					if (multipleTarBatchFoldersEnabled) {
+							object = processGroupedFolderTarsRequests(object, files, tarWorkDir, notesWriter);
 						
-						object = processGroupedFolderTarsRequests (object, files, tarWorkDir, notesWriter );
 					}else {
 					List<File> fileList = new ArrayList<>(Arrays.asList(files));
 					int expectedTarRequests = (fileList.size() + filesPerTar - 1) / filesPerTar;
@@ -401,7 +410,16 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 				logger.error("[{}] error {}", super.getTaskName(), e.getMessage(), e);
 				throw new DmeSyncStorageException("Error occurred during batch tarring. " + e.getMessage(), e);
 			}
-		}return object;
+		} 
+	}else {
+		logger.info("No need to upload folder : {}", object.getOriginalFilePath());
+		object.setStatus(WorkflowConstants.FAILED);
+		object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
+		object.setEndWorkflow(true);
+		object.setError("No need to upload yet");
+		object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
+	   } 
+		return object;
 
 	}
 
@@ -478,6 +496,8 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 
 		logger.info("[{}] Grouping enabled: delimiter='{}', level={}", super.getTaskName(), batchFolderDelimiter,
 				batchFolderDelimiterLevel);
+		
+		
 
 		// Only directories (site folders)
 		List<File> siteFolders = Arrays.stream(files).filter(File::isDirectory)

--- a/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/workflow/impl/DmeSyncProcessMultipleTarsTaskImpl.java
@@ -120,9 +120,9 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 				: null;
 		
 		DmeSyncPathMetadataProcessor metadataTask = metadataProcessorFactory.getService(doc);
-		if (metadataTask.isMetadataAvailable(object)) {
+		
 		  if (TarUtil.matchesAnyMultipleTarFolder( multipleTarsFolders , sourceDirLeafNode )) {
-			  
+			  if (metadataTask.isMetadataAvailable(object)) { 
 			try {
 
 				Path baseDirPath = Paths.get(syncBaseDir).toRealPath();
@@ -411,7 +411,7 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 				throw new DmeSyncStorageException("Error occurred during batch tarring. " + e.getMessage(), e);
 			}
 		} 
-	}else {
+	else {
 		logger.info("No need to upload folder : {}", object.getOriginalFilePath());
 		object.setStatus(WorkflowConstants.FAILED);
 		object.setRunId(WorkflowConstants.toIgnoredRunId(object.getRunId()));
@@ -419,6 +419,7 @@ public class DmeSyncProcessMultipleTarsTaskImpl extends AbstractDmeSyncTask impl
 		object.setError("No need to upload yet");
 		object = dmeSyncWorkflowService.getService(access).saveStatusInfo(object);
 	   } 
+	}
 		return object;
 
 	}


### PR DESCRIPTION
egarding the files picked up in the each scan

We are not sure whether the source path used will be the archive_staging folder. Instead of requiring the user to add a markup file to identify which folders should be added to the run, implement a custom change for lcbg-sds, similar to the existing gb-omics behavior.

Requested behavior:

For lcbg-sds:

If a record is not found in the spreadsheet, ignore the folder upload and do not include it in the run.
Add a new column named Archive to the report.
Archive behavior should be based on the Archive column value:
Yes or blank: archive the folder.
No: do not archive the folder.