### PR TITLE
 DMESUPPORT-219 Uploaded symlink files are picked up again during rer…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>gov.nih.nci.hpc</groupId>
 	<artifactId>dme-sync</artifactId>
-	<version>2.11.0</version>
+	<version>2.12.0</version>
 	<name>dme-sync</name>
 	<packaging>jar</packaging>
 	<description>DME Auto-archival Workflow Application</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>gov.nih.nci.hpc</groupId>
 	<artifactId>dme-sync</artifactId>
-	<version>2.12.0</version>
+	<version>2.11.1</version>
 	<name>dme-sync</name>
 	<packaging>jar</packaging>
 	<description>DME Auto-archival Workflow Application</description>

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -17,12 +17,12 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
   StatusInfo findFirstByOriginalFilePathAndStatusInOrderByStartTimestampDesc(String originalFilePath,  List<String> statuses);
   
   /**
-   * findFirstBySourceFilePathAndStatus
+   * findFirstBySourceFilePathAndStatusIn
    * @param sourceFilePath the source file path
-   * @param status the status
+   * @param statuses the List of the status
    * @return the StatusInfo object
    */
-  StatusInfo findFirstBySourceFilePathAndStatusInOrderByStartTimestampDesc(String sourceFilePath, List<String> status);
+  StatusInfo findFirstBySourceFilePathAndStatusInOrderByStartTimestampDesc(String sourceFilePath, List<String> statuses);
   
   /**
    * findFirstStatusInfoByFullDestinationPathAndStatus

--- a/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/dao/StatusInfoDao.java
@@ -22,7 +22,7 @@ public interface StatusInfoDao<T extends StatusInfo> extends JpaRepository<T, Lo
    * @param status the status
    * @return the StatusInfo object
    */
-  StatusInfo findFirstBySourceFilePathAndStatusOrderByStartTimestampDesc(String sourceFilePath, String status);
+  StatusInfo findFirstBySourceFilePathAndStatusInOrderByStartTimestampDesc(String sourceFilePath, List<String> status);
   
   /**
    * findFirstStatusInfoByFullDestinationPathAndStatus

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -322,6 +322,19 @@ public class DmeSyncScheduler {
       List<HpcPathAttributes> files = new ArrayList<>();
       if (paths != null && paths.isEmpty()) {
         logger.info("[Scheduler] No files/folders found for runID: {}", runId);
+
+        String emailBody= "There were no files/folders found for processing"+(!StringUtils.isEmpty(syncBaseDirFolders)?" in "+syncBaseDirFolders+" folders":"")+ ".";
+        dmeSyncMailServiceFactory.getService(doc).sendMail("HPCDME Auto Archival Result for " + doc + " - Base Path: " + syncBaseDir,
+  			  emailBody);
+        try {
+            dmeSyncWorkflowRunLogService.updateWorkflowRunEnd(runId, doc, WorkflowConstants.RunStatus.SKIPPED.toString(),null);
+          } catch (IllegalArgumentException e) {
+            logger.warn("[Scheduler] Workflow run not found when updating run end to SKIPPED for runId: {}, doc: {}", runId, doc, e);
+          }
+		if (shutDownFlag) {
+			logger.info("[Scheduler] No files/folders found. Shutting down the application.");
+			DmeSyncApplication.shutdown();
+		}
         MDC.clear();
         return;
       } else {

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -35,6 +35,7 @@ import org.springframework.util.CollectionUtils;
 import gov.nih.nci.hpc.dmesync.util.DmeMetadataBuilder;
 import gov.nih.nci.hpc.dmesync.util.HpcLocalDirectoryListQuery;
 import gov.nih.nci.hpc.dmesync.util.HpcPathAttributes;
+import gov.nih.nci.hpc.dmesync.util.PathUtil;
 import gov.nih.nci.hpc.dmesync.util.TarUtil;
 import gov.nih.nci.hpc.dmesync.util.WorkflowConstants;
 import gov.nih.nci.hpc.dmesync.workflow.impl.DmeSyncAWSScanDirectory;
@@ -752,7 +753,13 @@ public class DmeSyncScheduler {
 			logger.debug("[Scheduler] Checking for symbolic link Completed status: Original filepath : {} , SourceFilePath: {}",
 					fileFullPath, sourceFilePath);
 			statusInfo = dmeSyncWorkflowService.getService(access)
-					.findFirstStatusInfoBySourceFilePathAndStatus(sourceFilePath.toString(), "COMPLETED");
+					.findFirstStatusInfoBySourceFilePathAndStatusIn(sourceFilePath.toString(), WorkflowConstants.getNoReRunStatuses());
+			// Adding this below condition when status info is null because the old symlink records have 
+			  // both sourcefilepath,  originalfilepath as symbolic links
+			if(statusInfo == null) {
+				statusInfo = dmeSyncWorkflowService.getService(access)
+						.findFirstStatusInfoByOriginalFilePathAndStatusIn(fileFullPath.toString(),WorkflowConstants.getNoReRunStatuses());
+			}
 		}
 		else {
           statusInfo =
@@ -990,13 +997,13 @@ public class DmeSyncScheduler {
     }
   }
 
-  private StatusInfo insertRecordDb(HpcPathAttributes file, boolean completed) {
+  private StatusInfo insertRecordDb(HpcPathAttributes file, boolean completed) throws IOException {
     StatusInfo statusInfo = new StatusInfo();
     statusInfo.setRunId(runId);
     statusInfo.setOrginalFileName(file.getName());
     statusInfo.setOriginalFilePath(file.getAbsolutePath());
     statusInfo.setSourceFileName(untar ? file.getTarEntry() : file.getName());
-    statusInfo.setSourceFilePath(createCollectionSoftlink ? file.getPath() : file.getAbsolutePath());
+    statusInfo.setSourceFilePath(createCollectionSoftlink ? file.getPath() : PathUtil.resolveSourceFilePath(file.getAbsolutePath()));
     statusInfo.setFilesize(file.getSize());
     statusInfo.setStartTimestamp(new Date());
     statusInfo.setDoc(doc);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/scheduler/DmeSyncScheduler.java
@@ -745,15 +745,12 @@ public class DmeSyncScheduler {
 		                  file.getAbsolutePath(), file.getPath(), "COMPLETED");
 		}
 		else if (fileFullPath!=null && Files.isSymbolicLink(fileFullPath)) {
-			Path sourceFilePath = Files.readSymbolicLink(fileFullPath);
-			if (!sourceFilePath.isAbsolute()) {
-				sourceFilePath = fileFullPath.getParent().resolve(sourceFilePath).normalize();
-			}
-			sourceFilePath = sourceFilePath.toAbsolutePath();
-			logger.debug("[Scheduler] Checking for symbolic link Completed status: Original filepath : {} , SourceFilePath: {}",
+			
+			String sourceFilePath = PathUtil.resolveSourceFilePath(fileFullPath.toString());
+			logger.debug("[Scheduler] Checking for symbolic link rerun: Original filepath : {} , SourceFilePath: {}",
 					fileFullPath, sourceFilePath);
 			statusInfo = dmeSyncWorkflowService.getService(access)
-					.findFirstStatusInfoBySourceFilePathAndStatusIn(sourceFilePath.toString(), WorkflowConstants.getNoReRunStatuses());
+					.findFirstStatusInfoBySourceFilePathAndStatusIn(sourceFilePath, WorkflowConstants.getNoReRunStatuses());
 			// Adding this below condition when status info is null because the old symlink records have 
 			  // both sourcefilepath,  originalfilepath as symbolic links
 			if(statusInfo == null) {
@@ -997,7 +994,7 @@ public class DmeSyncScheduler {
     }
   }
 
-  private StatusInfo insertRecordDb(HpcPathAttributes file, boolean completed) throws IOException {
+  private StatusInfo insertRecordDb(HpcPathAttributes file, boolean completed){
     StatusInfo statusInfo = new StatusInfo();
     statusInfo.setRunId(runId);
     statusInfo.setOrginalFileName(file.getName());

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -331,13 +331,13 @@ public interface DmeSyncWorkflowService {
    
    
    /**
-    * findFirstStatusInfoBySourceFilePathAndStatus
+    * findFirstStatusInfoBySourceFilePathAndStatusIn
     *
     * @param sourceFilePath the source file path
-    * @param status the status
+    * @param statuses the List of the status
     * @return the StatusInfo object
     */
-   StatusInfo findFirstStatusInfoBySourceFilePathAndStatusIn(String sourceFilePath, List<String> status);
+   StatusInfo findFirstStatusInfoBySourceFilePathAndStatusIn(String sourceFilePath, List<String> statuses);
 
    StatusInfo findFirstStatusInfoByOriginalFilePathAndSourceFilePathNotEndsWith(String originalFilePath,
 		String sourceFilePath);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/DmeSyncWorkflowService.java
@@ -337,7 +337,7 @@ public interface DmeSyncWorkflowService {
     * @param status the status
     * @return the StatusInfo object
     */
-   StatusInfo findFirstStatusInfoBySourceFilePathAndStatus(String sourceFilePath, String status);
+   StatusInfo findFirstStatusInfoBySourceFilePathAndStatusIn(String sourceFilePath, List<String> status);
 
    StatusInfo findFirstStatusInfoByOriginalFilePathAndSourceFilePathNotEndsWith(String originalFilePath,
 		String sourceFilePath);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -66,8 +66,8 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   
   @Override
   public StatusInfo findFirstStatusInfoBySourceFilePathAndStatusIn(
-      String sourceFilePath, List<String> status) {
-    return statusInfoDao.findFirstBySourceFilePathAndStatusInOrderByStartTimestampDesc(sourceFilePath, status);
+      String sourceFilePath, List<String> statuses) {
+    return statusInfoDao.findFirstBySourceFilePathAndStatusInOrderByStartTimestampDesc(sourceFilePath, statuses);
   }
   
   @Override

--- a/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/service/impl/DmeSyncWorkflowServiceImpl.java
@@ -65,9 +65,9 @@ public class DmeSyncWorkflowServiceImpl implements DmeSyncWorkflowService {
   }
   
   @Override
-  public StatusInfo findFirstStatusInfoBySourceFilePathAndStatus(
-      String sourceFilePath, String status) {
-    return statusInfoDao.findFirstBySourceFilePathAndStatusOrderByStartTimestampDesc(sourceFilePath, status);
+  public StatusInfo findFirstStatusInfoBySourceFilePathAndStatusIn(
+      String sourceFilePath, List<String> status) {
+    return statusInfoDao.findFirstBySourceFilePathAndStatusInOrderByStartTimestampDesc(sourceFilePath, status);
   }
   
   @Override

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/PathUtil.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/PathUtil.java
@@ -31,7 +31,7 @@ public class PathUtil {
 	 *         otherwise the original path
 	 * @throws IOException if an I/O error occurs while reading the symbolic link
 	 */
-	public static String resolveSourceFilePath(String absolutePath) throws IOException {
+	public static String resolveSourceFilePath(String absolutePath)  {
 
 		if (absolutePath == null) {
 			return null;
@@ -51,8 +51,8 @@ public class PathUtil {
 
 			return targetPath.toAbsolutePath().toString();
 		} catch (IOException e) {
-			logger.error("Error resolving source file path for {}: {}", absolutePath, e.getMessage());
-			throw e;
+			logger.error("Error resolving source file path for {}: {}", absolutePath, e);
+			return null;
 		}
 	}
 

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/PathUtil.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/PathUtil.java
@@ -1,0 +1,59 @@
+package gov.nih.nci.hpc.dmesync.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PathUtil {
+
+	static final Logger logger = LoggerFactory.getLogger(PathUtil.class);
+
+	private PathUtil() {
+	}
+
+	/**
+	 * Resolves the source file path for archival.
+	 *
+	 * <p>
+	 * For regular files, this returns the file's absolute path. For symbolic links,
+	 * this returns the absolute path of the symlink target,
+	 *
+	 * <p>
+	 * If the symbolic link target is relative, it is resolved against the symlink's
+	 * parent directory and normalized before being converted to an absolute path.
+	 *
+	 * @param absolutePath the absolute path of the scanned file or symlink
+	 * @return the resolved source file path; for symlinks, the target path,
+	 *         otherwise the original path
+	 * @throws IOException if an I/O error occurs while reading the symbolic link
+	 */
+	public static String resolveSourceFilePath(String absolutePath) throws IOException {
+
+		if (absolutePath == null) {
+			return null;
+		}
+
+		try {
+
+			Path fileFullPath = Paths.get(absolutePath);
+			if (!Files.isSymbolicLink(fileFullPath)) {
+				return absolutePath;
+			}
+
+			Path targetPath = Files.readSymbolicLink(fileFullPath);
+			if (!targetPath.isAbsolute()) {
+				targetPath = fileFullPath.getParent().resolve(targetPath).normalize();
+			}
+
+			return targetPath.toAbsolutePath().toString();
+		} catch (IOException e) {
+			logger.error("Error resolving source file path for {}: {}", absolutePath, e.getMessage());
+			throw e;
+		}
+	}
+
+}


### PR DESCRIPTION
Background:

In compass recent workflow,54 older symlink files that were already uploaded were picked up again during the scan.

This happened because, in the recent release, the rerun check logic was changed to validate uploads based on the source file path instead of the original file path. However, the framework is not setting the source file path to the target file of the symlink. As a result, both the original file path and the source file path contain the symlink name, causing these files to be picked up again.

Resolution:

The issue will be fixed in the framework. When the uploaded file is a symlink, the framework should set the original file path to the symlink name and the source file path to the target file.

For existing rows, the rerun scan logic should first check for completed records in the database based on the source file path. If completed records are found, it should then check based on the original file path to ensure already uploaded symlink files are not picked up again.


Another Minor fix also added in this patch release
When the source directory is empty or the scan does not find any files, the workflow currently does not send the “No files found” email.

The fix is to send the email, update the status in the workflow_run_info table, and shut down the application if the shutdown flag is enabled.