### PR TITLE
DMESUPPORT-220 Enhance the Excel report generation to improve visibility of failed items by highlighting entire rows in yellow

### DIFF
--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/ExcelUtil.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/ExcelUtil.java
@@ -183,15 +183,17 @@ public class ExcelUtil {
           }
         }
         if (highlightFailure) {
-        	  for (int i = 0; i < colCount; i++) {
-        	    Cell cell = row.getCell(i);
-        	    if (cell == null) {
-        	      cell = row.createCell(i);
-        	    }
-        	    cell.setCellStyle(failedRowStyle);
-        	  }
+            int totalColumns = Math.max(header.getLastCellNum(), 50); 
+            for (int i = 0; i < totalColumns; i++) {
+              Cell cell = row.getCell(i);
+              if (cell == null) {
+                cell = row.createCell(i);
+                cell.setCellValue("");
+              }
+              cell.setCellStyle(failedRowStyle);
+            }
+          }
         }
-      }
       
 
       workbook.write(outputStream);

--- a/src/main/java/gov/nih/nci/hpc/dmesync/util/ExcelUtil.java
+++ b/src/main/java/gov/nih/nci/hpc/dmesync/util/ExcelUtil.java
@@ -39,6 +39,8 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.apache.poi.ss.usermodel.IndexedColors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import gov.nih.nci.hpc.dmesync.domain.MetadataInfo;
@@ -71,6 +73,11 @@ public class ExcelUtil {
     headerFont.setBold(true);
     CellStyle headerCellStyle = workbook.createCellStyle();
     headerCellStyle.setFont(headerFont);
+
+	 // Create yellow style for failed rows
+    CellStyle failedRowStyle = workbook.createCellStyle();
+    failedRowStyle.setFillForegroundColor(IndexedColors.YELLOW.getIndex());
+    failedRowStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
 
     try (FileOutputStream outputStream = new FileOutputStream(fileName); ) {
 
@@ -113,6 +120,7 @@ public class ExcelUtil {
     	    cell.setCellStyle(headerCellStyle);
      }
       for (StatusInfo data : statusInfo) {
+        boolean highlightFailure = !WorkflowConstants.isCompletedStatus(data.getStatus());
         colCount = 0;
         Row row = sheet.createRow(rowCount++);
         row.createCell(colCount++).setCellValue(data.getRunId());
@@ -174,7 +182,17 @@ public class ExcelUtil {
             row.createCell(colCount++).setCellValue("");
           }
         }
+        if (highlightFailure) {
+        	  for (int i = 0; i < colCount; i++) {
+        	    Cell cell = row.getCell(i);
+        	    if (cell == null) {
+        	      cell = row.createCell(i);
+        	    }
+        	    cell.setCellStyle(failedRowStyle);
+        	  }
+        }
       }
+      
 
       workbook.write(outputStream);
 


### PR DESCRIPTION
Enhance the Excel report generation to improve visibility of failed items by highlighting entire rows in yellow when a file/run entry is not successfully completed. This will make failures easier to identify during report review, especially in large exports. The update should apply the highlight consistently across all columns for failed rows while leaving successful rows unchanged. Attached testing report

**
<img width="1911" height="812" alt="image" src="https://github.com/user-attachments/assets/cc316a4d-c618-4936-b500-8c1355edc10f" />
**